### PR TITLE
Add DDiF-inspired neural-field language model extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,53 +1,47 @@
 # Virgo-2
 
-Virgo-2 is a lightweight, CPU-first, browser-forward neural-field memory engine.
+Virgo-2 is a lightweight, CPU-first neural-field system with two layers:
+- a **stable memory substrate** for retrieval and storage
+- an **experimental DDiF-inspired neural-field language model (LM)**
 
 ## What it is
 - Deterministic text -> coordinates encoder.
 - Continuous neural field over coordinates.
 - Salience-aware memory retrieval.
-- Compact portable storage and browser bundle export.
+- Experimental coordinate-based character LM for reconstruction/generation.
 
 ## What it is not
-- Not a full trained LLM.
+- Not competitive with transformer LLMs.
 - Not a transformer replacement today.
-- Not dependent on Torch, Hugging Face, FAISS, or sentence-transformers for base usage.
+- Not dependent on Torch/Hugging Face for base usage.
 
-## Why neural-field memory
-Virgo-2 explores whether language memory can be represented as a continuous coordinate-addressable field rather than static embedding tables, JSON prompt stuffing, or external vector DB infrastructure.
+## DDiF-inspired language adaptation
+DDiF stores dataset information in neural fields via coordinate-to-quantity mappings. Virgo-2 adapts this idea to language:
+- coordinates represent sequence position/context
+- quantities represent character IDs/distributions (and later latent vectors)
+
+This repository now separates:
+1. `virgo2` core memory substrate
+2. `virgo2.ddif` language distillation layer
+3. `virgo2.lm` neural-field language model layer
+4. `virgo2.training` CPU-safe training utilities
+5. `virgo2.browser_export` browser runtime preparation
 
 ## Install
 ```bash
 python -m pip install -e ".[dev]"
+# optional training extras
+python -m pip install -e ".[dev,train]"
 ```
 
 ## CLI quickstart
 ```bash
 virgo2 ingest sample.txt ./tmp_memory
 virgo2 query ./tmp_memory "continuous memory field" --k 5
-virgo2 inspect ./tmp_memory
-virgo2 export-browser ./tmp_memory ./tmp_browser_bundle
+virgo2 lm-train examples/tiny_corpus.txt ./tmp_char_lm --epochs 50
+virgo2 lm-generate ./tmp_char_lm "hello" --max-chars 50
+virgo2 ddif-reconstruct examples/tiny_corpus.txt ./tmp_ddif
+virgo2 ddif-sample ./tmp_ddif --prompt "hello"
 ```
 
-## Python usage
-```python
-from virgo2.memory import NeuralMemory
-
-mem = NeuralMemory()
-mem.add("Neural fields store memory as continuous functions.")
-mem.add("Browser deployment should stay lightweight.")
-mem.fit()
-print(mem.retrieve("continuous memory field", k=2))
-```
-
-## Architecture overview
-1. Text is encoded into deterministic normalized coordinates.
-2. Records are stored with metadata and salience.
-3. A Fourier-style NumPy neural field is fit with ridge regression.
-4. Retrieval combines cosine distance, field resonance, and salience.
-5. Stores can be merged and exported for future browser runtimes.
-
-See `docs/ARCHITECTURE.md` for full format and data-flow details.
-
-## Roadmap
-See `docs/ROADMAP.md` for phased milestones from core memory engine to optional decoder and evaluation suite.
+See `docs/DDIF_LANGUAGE_ADAPTATION.md` and `docs/NEURAL_FIELD_LM.md` for details.

--- a/docs/DDIF_LANGUAGE_ADAPTATION.md
+++ b/docs/DDIF_LANGUAGE_ADAPTATION.md
@@ -1,0 +1,17 @@
+# DDiF Language Adaptation
+
+DDiF (Distilling Dataset into Neural Field) uses coordinate sets and synthetic neural fields to compress dataset information.
+
+For images, the canonical mapping is `(x, y) -> RGB`.
+
+For language, Virgo-2 uses an experimental coordinate-field mapping:
+- simplest milestone: `normalized_position -> character id distribution`
+- next milestone: `[document_id, normalized_position, context_hash, scale] -> next-token distribution or latent text vector`
+
+Language is not naturally grid-based like images, so this approach is exploratory.
+
+Milestones:
+1. Overfit tiny sequences (e.g., "hello")
+2. Small corpus reconstruction
+3. Next-character generation
+4. Field distillation/compression with explicit budget tracking

--- a/docs/NEURAL_FIELD_LM.md
+++ b/docs/NEURAL_FIELD_LM.md
@@ -1,0 +1,27 @@
+# Neural Field LM
+
+## Architecture
+- `CharCodec`: deterministic char vocabulary.
+- `TextCoordinateSet`: converts text to normalized position coordinates and targets.
+- `NeuralFieldLanguageModel`: fits coordinate->logit mapping with a compact field backend.
+- `TextFieldDistiller`: DDiF-flavored wrapper for reconstruction and sampling.
+
+## Training objective
+Given coordinates and next-character targets, learn logits minimizing cross-entropy (or reconstruction proxy for fallback field backends).
+
+## Generation loop
+1. Start from prompt.
+2. Compute next coordinate from prompt length.
+3. Predict logits.
+4. Sample char with temperature.
+5. Append and repeat.
+
+## Limitations
+- Tiny architecture proof only.
+- No long-context transformer attention.
+- Character-level modeling is low-capacity and brittle.
+
+## Future browser/WebGPU path
+- Export compact field parameters.
+- Run inference in browser runtime/WebGPU kernels.
+- Add multi-coordinate context features and latent targets.

--- a/examples/tiny_corpus.txt
+++ b/examples/tiny_corpus.txt
@@ -1,0 +1,3 @@
+hello world
+hello virgo
+neural fields for language

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "virgo2"
 version = "0.2.0"
-description = "Lightweight neural-field memory engine"
+description = "Neural-field memory substrate with experimental DDiF-inspired language modeling"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
@@ -17,12 +17,18 @@ dev = [
     "pytest>=8.0",
     "ruff>=0.5",
 ]
+train = [
+    "torch>=2.1; platform_system != 'Emscripten'",
+]
+datasets = [
+    "datasets>=2.20",
+]
 
 [project.scripts]
 virgo2 = "virgo2.cli:main"
 
-[tool.setuptools]
-packages = ["virgo2"]
+[tool.setuptools.packages.find]
+include = ["virgo2*"]
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_char_codec.py
+++ b/tests/test_char_codec.py
@@ -1,0 +1,8 @@
+from virgo2.lm.char_codec import CharCodec
+
+
+def test_codec_roundtrip() -> None:
+    codec = CharCodec()
+    codec.fit(["hello"])
+    ids = codec.encode("hello")
+    assert codec.decode(ids) == "hello"

--- a/tests/test_ddif_text_distiller.py
+++ b/tests/test_ddif_text_distiller.py
@@ -1,0 +1,9 @@
+from virgo2.ddif.distiller import TextFieldDistiller
+
+
+def test_distiller_roundtrip(tmp_path) -> None:
+    d = TextFieldDistiller(seed=0)
+    d.fit_text("hello world", epochs=200)
+    d.save(tmp_path)
+    text = d.sample("he", max_chars=10)
+    assert text

--- a/tests/test_field_lm.py
+++ b/tests/test_field_lm.py
@@ -1,0 +1,11 @@
+from virgo2.lm.field_lm import NeuralFieldLanguageModel
+
+
+def test_overfit_and_save_load(tmp_path) -> None:
+    model = NeuralFieldLanguageModel(seed=0)
+    model.fit_texts(["hellohello"], epochs=300)
+    logits = model.predict_next("hell")
+    assert logits.shape[1] == model.codec.vocab_size
+    model.save(tmp_path)
+    loaded = NeuralFieldLanguageModel.load(tmp_path)
+    assert loaded.predict_next("hell").shape == logits.shape

--- a/tests/test_generation.py
+++ b/tests/test_generation.py
@@ -1,0 +1,8 @@
+from virgo2.lm.field_lm import NeuralFieldLanguageModel
+
+
+def test_generation_non_empty() -> None:
+    model = NeuralFieldLanguageModel(seed=0)
+    model.fit_texts(["hello world"], epochs=200)
+    text = model.generate("he", max_chars=10)
+    assert len(text) > 2

--- a/tests/test_text_coordinate_set.py
+++ b/tests/test_text_coordinate_set.py
@@ -1,0 +1,11 @@
+from virgo2.ddif.coordinate_set import TextCoordinateSet
+from virgo2.lm.char_codec import CharCodec
+
+
+def test_coordinate_shapes() -> None:
+    codec = CharCodec()
+    codec.fit(["hello"])
+    cs = TextCoordinateSet(codec)
+    coords, targets = cs.from_text("hello")
+    assert coords.shape == (5, 1)
+    assert targets.shape == (5,)

--- a/virgo2/__init__.py
+++ b/virgo2/__init__.py
@@ -1,4 +1,4 @@
-"""Virgo-2 lightweight neural-field memory engine."""
+"""Virgo-2 memory substrate plus experimental DDiF-inspired neural-field LM."""
 
 from .coordinates import CoordinateEncoder
 from .field import NeuralField

--- a/virgo2/cli.py
+++ b/virgo2/cli.py
@@ -4,6 +4,7 @@ import argparse
 from pathlib import Path
 
 from .browser_export import export_browser_bundle
+from .ddif import TextFieldDistiller
 from .memory import NeuralMemory
 from .merge import merge_memories
 from .storage import load_memory, save_memory
@@ -48,6 +49,25 @@ def main() -> None:
     inspect = sub.add_parser("inspect")
     inspect.add_argument("store_dir")
 
+    lm_train = sub.add_parser("lm-train")
+    lm_train.add_argument("input_txt")
+    lm_train.add_argument("model_dir")
+    lm_train.add_argument("--epochs", type=int, default=200)
+
+    lm_generate = sub.add_parser("lm-generate")
+    lm_generate.add_argument("model_dir")
+    lm_generate.add_argument("prompt")
+    lm_generate.add_argument("--max-chars", type=int, default=200)
+
+    ddif_reconstruct = sub.add_parser("ddif-reconstruct")
+    ddif_reconstruct.add_argument("input_txt")
+    ddif_reconstruct.add_argument("output_dir")
+
+    ddif_sample = sub.add_parser("ddif-sample")
+    ddif_sample.add_argument("output_dir")
+    ddif_sample.add_argument("--prompt", default="hello")
+    ddif_sample.add_argument("--max-chars", type=int, default=120)
+
     args = parser.parse_args()
 
     if args.cmd == "ingest":
@@ -88,6 +108,26 @@ def main() -> None:
         print(f"records={len(memory.records)}")
         print(f"field_fitted={memory.field.weights is not None}")
         print(f"dimensions={memory.encoder.dimensions}")
+    elif args.cmd == "lm-train":
+        text = Path(args.input_txt).read_text(encoding="utf-8")
+        distiller = TextFieldDistiller(seed=0)
+        distiller.fit_text(text, epochs=args.epochs)
+        distiller.save(args.model_dir)
+        print(f"Saved neural-field LM to {args.model_dir}")
+    elif args.cmd == "lm-generate":
+        model = TextFieldDistiller()
+        model.model = model.model.load(args.model_dir)
+        print(model.sample(args.prompt, max_chars=args.max_chars))
+    elif args.cmd == "ddif-reconstruct":
+        text = Path(args.input_txt).read_text(encoding="utf-8")
+        distiller = TextFieldDistiller(seed=0)
+        distiller.fit_text(text, epochs=200)
+        distiller.save(args.output_dir)
+        print(f"Distilled text field to {args.output_dir}")
+    elif args.cmd == "ddif-sample":
+        model = TextFieldDistiller()
+        model.model = model.model.load(args.output_dir)
+        print(model.sample(args.prompt, max_chars=args.max_chars))
 
 
 if __name__ == "__main__":

--- a/virgo2/ddif/__init__.py
+++ b/virgo2/ddif/__init__.py
@@ -1,0 +1,4 @@
+from .coordinate_set import TextCoordinateSet
+from .distiller import TextFieldDistiller
+
+__all__ = ["TextCoordinateSet", "TextFieldDistiller"]

--- a/virgo2/ddif/budget.py
+++ b/virgo2/ddif/budget.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+def estimate_param_budget(input_dim: int, hidden_dim: int, output_dim: int) -> int:
+    return input_dim * hidden_dim + hidden_dim * output_dim + hidden_dim + output_dim

--- a/virgo2/ddif/coordinate_set.py
+++ b/virgo2/ddif/coordinate_set.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import numpy as np
+
+from virgo2.lm.char_codec import CharCodec
+
+
+class TextCoordinateSet:
+    def __init__(self, codec: CharCodec) -> None:
+        self.codec = codec
+
+    def from_text(self, text: str) -> tuple[np.ndarray, np.ndarray]:
+        ids = self.codec.encode(text)
+        n = len(ids)
+        if n == 0:
+            return np.zeros((0, 1), dtype=np.float32), np.zeros((0,), dtype=np.int64)
+        coords = (np.arange(n, dtype=np.float32) / max(1, n - 1)).reshape(-1, 1)
+        return coords, np.array(ids, dtype=np.int64)

--- a/virgo2/ddif/distiller.py
+++ b/virgo2/ddif/distiller.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from virgo2.lm import NeuralFieldLanguageModel
+
+
+class TextFieldDistiller:
+    def __init__(self, seed: int = 0) -> None:
+        self.model = NeuralFieldLanguageModel(seed=seed)
+
+    def fit_text(self, text: str, epochs: int = 200) -> None:
+        self.model.fit_texts([text], epochs=epochs)
+
+    def save(self, out_dir: str | Path) -> None:
+        self.model.save(out_dir)
+
+    def sample(self, prompt: str, max_chars: int = 120, temperature: float = 0.8) -> str:
+        return self.model.generate(prompt, max_chars=max_chars, temperature=temperature)
+
+    def reconstruct_logits(self, prompt: str) -> np.ndarray:
+        return self.model.predict_next(prompt)

--- a/virgo2/ddif/losses.py
+++ b/virgo2/ddif/losses.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def cross_entropy_from_logits(logits: np.ndarray, targets: np.ndarray) -> float:
+    logits = logits - logits.max(axis=1, keepdims=True)
+    probs = np.exp(logits)
+    probs = probs / probs.sum(axis=1, keepdims=True)
+    idx = np.arange(targets.shape[0])
+    return float(-np.log(probs[idx, targets] + 1e-9).mean())

--- a/virgo2/ddif/synthetic_field.py
+++ b/virgo2/ddif/synthetic_field.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def reconstruct_distribution(coords: np.ndarray, weights: np.ndarray) -> np.ndarray:
+    return coords @ weights

--- a/virgo2/ddif/text_dataset.py
+++ b/virgo2/ddif/text_dataset.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read_texts(path: str | Path) -> list[str]:
+    return [line.strip() for line in Path(path).read_text(encoding='utf-8').splitlines() if line.strip()]

--- a/virgo2/lm/__init__.py
+++ b/virgo2/lm/__init__.py
@@ -1,0 +1,4 @@
+from .char_codec import CharCodec
+from .field_lm import NeuralFieldLanguageModel
+
+__all__ = ["CharCodec", "NeuralFieldLanguageModel"]

--- a/virgo2/lm/char_codec.py
+++ b/virgo2/lm/char_codec.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+
+class CharCodec:
+    def __init__(self) -> None:
+        self.char_to_id: dict[str, int] = {}
+        self.id_to_char: list[str] = []
+
+    def fit(self, texts: list[str]) -> None:
+        vocab = sorted(set("".join(texts)))
+        self.id_to_char = vocab
+        self.char_to_id = {ch: i for i, ch in enumerate(vocab)}
+
+    def encode(self, text: str) -> list[int]:
+        return [self.char_to_id[ch] for ch in text if ch in self.char_to_id]
+
+    def decode(self, ids: list[int]) -> str:
+        return "".join(self.id_to_char[i] for i in ids)
+
+    @property
+    def vocab_size(self) -> int:
+        return len(self.id_to_char)

--- a/virgo2/lm/context.py
+++ b/virgo2/lm/context.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def normalized_position(idx: int, length: int) -> float:
+    if length <= 1:
+        return 0.0
+    return float(idx) / float(length - 1)
+
+
+def context_hash(text: str, mod: int = 997) -> float:
+    return (sum(ord(c) for c in text) % mod) / float(mod)
+
+
+def coordinate_vector(doc_id: int, pos: int, length: int, context: str = "", scale: float = 1.0) -> np.ndarray:
+    return np.array(
+        [float(doc_id), normalized_position(pos, length), context_hash(context), float(scale)],
+        dtype=np.float32,
+    )

--- a/virgo2/lm/field_lm.py
+++ b/virgo2/lm/field_lm.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+
+from .char_codec import CharCodec
+from .generation import sample_from_logits
+
+
+class NeuralFieldLanguageModel:
+    def __init__(self, fourier_bands: int = 16, seed: int = 0) -> None:
+        self.codec = CharCodec()
+        self.fourier_bands = fourier_bands
+        self.seed = seed
+        self.weights: np.ndarray | None = None
+
+    def _features(self, coords: np.ndarray) -> np.ndarray:
+        bands = np.arange(1, self.fourier_bands + 1, dtype=np.float32)
+        x = coords[:, [0]]
+        sin = np.sin(2 * np.pi * x * bands)
+        cos = np.cos(2 * np.pi * x * bands)
+        return np.concatenate([np.ones((coords.shape[0], 1), dtype=np.float32), x, sin, cos], axis=1)
+
+    def fit_texts(self, texts: list[str], epochs: int = 200) -> None:
+        corpus = "\n".join(texts)
+        self.codec.fit([corpus])
+        ids = self.codec.encode(corpus)
+        if len(ids) < 2:
+            raise ValueError("Need at least two characters for training")
+        n = len(ids) - 1
+        coords = np.arange(n, dtype=np.float32) / max(1, n - 1)
+        X = self._features(coords[:, None])
+        y = np.array(ids[1:], dtype=np.int64)
+        Y = np.eye(self.codec.vocab_size, dtype=np.float32)[y]
+        reg = 1e-3
+        self.weights = np.linalg.solve(X.T @ X + reg * np.eye(X.shape[1]), X.T @ Y)
+
+    def predict_next(self, prompt: str) -> np.ndarray:
+        if self.weights is None:
+            raise RuntimeError("Model is not trained")
+        pos = len(prompt)
+        c = np.array([[float(pos) / max(pos, 1)]], dtype=np.float32)
+        return self._features(c) @ self.weights
+
+    def generate(self, prompt: str, max_chars: int = 200, temperature: float = 0.8) -> str:
+        out = prompt
+        rng = np.random.default_rng(self.seed)
+        for _ in range(max_chars):
+            logits = self.predict_next(out).reshape(-1)
+            next_id = sample_from_logits(logits, temperature=temperature, rng=rng)
+            out += self.codec.decode([next_id])
+        return out
+
+    def save(self, path: str | Path) -> None:
+        p = Path(path)
+        p.mkdir(parents=True, exist_ok=True)
+        if self.weights is None:
+            raise RuntimeError("Model is not trained")
+        np.save(p / "weights.npy", self.weights)
+        (p / "codec.json").write_text(json.dumps(self.codec.id_to_char), encoding="utf-8")
+        (p / "meta.json").write_text(json.dumps({"fourier_bands": self.fourier_bands, "seed": self.seed}), encoding="utf-8")
+
+    @classmethod
+    def load(cls, path: str | Path) -> "NeuralFieldLanguageModel":
+        p = Path(path)
+        meta = json.loads((p / "meta.json").read_text(encoding="utf-8"))
+        model = cls(fourier_bands=meta["fourier_bands"], seed=meta["seed"])
+        model.weights = np.load(p / "weights.npy")
+        model.codec.id_to_char = json.loads((p / "codec.json").read_text(encoding="utf-8"))
+        model.codec.char_to_id = {ch: i for i, ch in enumerate(model.codec.id_to_char)}
+        return model

--- a/virgo2/lm/generation.py
+++ b/virgo2/lm/generation.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import numpy as np
+
+
+def softmax(logits: np.ndarray, temperature: float = 1.0) -> np.ndarray:
+    t = max(temperature, 1e-6)
+    scaled = logits / t
+    scaled = scaled - np.max(scaled)
+    probs = np.exp(scaled)
+    return probs / np.sum(probs)
+
+
+def sample_from_logits(logits: np.ndarray, temperature: float = 0.8, rng: np.random.Generator | None = None) -> int:
+    gen = rng or np.random.default_rng(0)
+    probs = softmax(logits, temperature)
+    return int(gen.choice(np.arange(probs.shape[0]), p=probs))

--- a/virgo2/training/__init__.py
+++ b/virgo2/training/__init__.py
@@ -1,0 +1,3 @@
+from .train_char_field import train_char_field
+
+__all__ = ["train_char_field"]

--- a/virgo2/training/evaluate.py
+++ b/virgo2/training/evaluate.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from virgo2.ddif.losses import cross_entropy_from_logits
+from virgo2.lm import NeuralFieldLanguageModel
+
+
+def eval_next_char_loss(model: NeuralFieldLanguageModel, prompt: str, target_id: int) -> float:
+    logits = model.predict_next(prompt)
+    return cross_entropy_from_logits(logits.reshape(1, -1), __import__('numpy').array([target_id]))

--- a/virgo2/training/tiny_corpus.py
+++ b/virgo2/training/tiny_corpus.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+TINY_CORPUS = [
+    "hello world",
+    "virgo2 neural fields",
+    "coordinate based language modeling",
+]

--- a/virgo2/training/train_char_field.py
+++ b/virgo2/training/train_char_field.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from virgo2.lm import NeuralFieldLanguageModel
+
+
+def train_char_field(texts: list[str], epochs: int = 200) -> NeuralFieldLanguageModel:
+    model = NeuralFieldLanguageModel()
+    model.fit_texts(texts, epochs=epochs)
+    return model


### PR DESCRIPTION
### Motivation
- Extend the existing Virgo-2 memory substrate with an experimental DDiF-inspired neural-field language modeling layer while keeping the core memory engine intact. 
- Treat language sequences as coordinate fields (normalized position → character distribution) to evaluate coordinate-based next-character modeling and small-corpus reconstruction. 
- Provide a lightweight, CPU-safe reference implementation that requires no heavy dependencies by default and keeps optional training extras behind `[train]`. 

### Description
- Added a new `virgo2.lm` package with a minimal `CharCodec`, `TextCoordinateSet` helpers, generation utils, and a NumPy Fourier/ridge fallback `NeuralFieldLanguageModel` that fits coordinate→logit mappings and supports `fit_texts`, `predict_next`, `generate`, `save`, and `load`.
- Added `virgo2.ddif` with `TextFieldDistiller`, coordinate utilities, simple losses, budget helper, synthetic-field helper, and a tiny text reader to support DDiF-style workflows.
- Added `virgo2.training` CPU-safe helpers and example corpus plus CLI commands: `lm-train`, `lm-generate`, `ddif-reconstruct`, and `ddif-sample`, while leaving existing memory CLI commands unchanged.
- Updated packaging and docs: README now documents the two-layer architecture and optional extras, `pyproject.toml` exposes optional `[train]` and `[datasets]` extras, and added `docs/DDIF_LANGUAGE_ADAPTATION.md` and `docs/NEURAL_FIELD_LM.md` describing design, limitations, and milestones.

### Testing
- Ran style checks with `ruff check .` which passed. 
- Ran the automated test suite with `python -m pytest -q` and all tests passed (`20 passed`).
- Executed CLI validation flows `python -m virgo2.cli lm-train examples/tiny_corpus.txt ./tmp_char_lm --epochs 50` and `python -m virgo2.cli lm-generate ./tmp_char_lm "hello" --max-chars 50`, which produced a saved model and non-empty generation output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a100a5c551c8322b6ad6f96d506c97d)