### PR TITLE
Add continuous field lifecycle, conversational memory, vault/registry, retrieval, consolidation, and ForgeLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,24 @@
 # Virgo-2
 
-Virgo-2 is a lightweight, CPU-first neural-field system with two layers:
-- a **stable memory substrate** for retrieval and storage
-- an **experimental DDiF-inspired neural-field language model (LM)**
+Virgo-2 is a lightweight neural-field memory and language-model research system with three layers:
+1. Core neural-field memory substrate.
+2. Continuous field lifecycle + conversational memory.
+3. Experimental DDiF-inspired neural-field LM.
 
-## What it is
-- Deterministic text -> coordinates encoder.
-- Continuous neural field over coordinates.
-- Salience-aware memory retrieval.
-- Experimental coordinate-based character LM for reconstruction/generation.
-
-## What it is not
-- Not competitive with transformer LLMs.
-- Not a transformer replacement today.
-- Not dependent on Torch/Hugging Face for base usage.
-
-## DDiF-inspired language adaptation
-DDiF stores dataset information in neural fields via coordinate-to-quantity mappings. Virgo-2 adapts this idea to language:
-- coordinates represent sequence position/context
-- quantities represent character IDs/distributions (and later latent vectors)
-
-This repository now separates:
-1. `virgo2` core memory substrate
-2. `virgo2.ddif` language distillation layer
-3. `virgo2.lm` neural-field language model layer
-4. `virgo2.training` CPU-safe training utilities
-5. `virgo2.browser_export` browser runtime preparation
+This is **not GPT-class**, not production AGI, and generation remains experimental.
+Field folding is deterministic/simple. Memory is early-stage but functional.
 
 ## Install
 ```bash
 python -m pip install -e ".[dev]"
-# optional training extras
-python -m pip install -e ".[dev,train]"
 ```
 
-## CLI quickstart
+## Lifecycle quickstart
 ```bash
-virgo2 ingest sample.txt ./tmp_memory
-virgo2 query ./tmp_memory "continuous memory field" --k 5
-virgo2 lm-train examples/tiny_corpus.txt ./tmp_char_lm --epochs 50
-virgo2 lm-generate ./tmp_char_lm "hello" --max-chars 50
-virgo2 ddif-reconstruct examples/tiny_corpus.txt ./tmp_ddif
-virgo2 ddif-sample ./tmp_ddif --prompt "hello"
+virgo2 vault-init ./vault
+virgo2 remember ./vault "Remember that Virgo-2 is a neural-field LM."
+virgo2 recall ./vault "What is Virgo-2?"
+virgo2 chat-memory ./vault "Do you remember what I am building?"
+virgo2 fold ./vault conversation_core folded_conversation_0001
+virgo2 forge-check ./vault
 ```
-
-See `docs/DDIF_LANGUAGE_ADAPTATION.md` and `docs/NEURAL_FIELD_LM.md` for details.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -27,3 +27,6 @@ Browser export writes `field.npz`, `records.tsv`, `manifest.txt`, and a mini REA
 
 ## Future Decoder Layer
 A tiny optional decoder may be added later as an experimental module over this substrate.
+
+## Continuous Lifecycle Layer
+Virgo-2 now includes vault-managed fields, TSV registry, conversational memory routing, deterministic folding/merging, and ForgeLite validation.

--- a/docs/CONVERSATIONAL_MEMORY.md
+++ b/docs/CONVERSATIONAL_MEMORY.md
@@ -1,0 +1,6 @@
+# Conversational Memory
+`ConversationMemory` stores user/assistant turns in `conversation_core` and extracts stable facts into identity/project/procedural/semantic fields.
+
+`context_for()` returns a readable context pack from multi-field retrieval.
+
+Learning is on-the-fly and deterministic (rule-based extraction).

--- a/docs/FIELD_FOLDING.md
+++ b/docs/FIELD_FOLDING.md
@@ -1,0 +1,9 @@
+# Field Folding
+Field bloat occurs as records accumulate. Folding preserves high-salience records and summarizes lower-salience clusters.
+
+- Sort by salience.
+- Keep high-salience top slice.
+- Summarize low-salience tail deterministically.
+- Save folded target and lineage in registry (`folded_from`).
+
+Limits: no LLM summarizer; summaries are heuristic and compact only.

--- a/docs/FIELD_LIFECYCLE.md
+++ b/docs/FIELD_LIFECYCLE.md
@@ -1,0 +1,8 @@
+# Field Lifecycle
+Fields are compact neural memory surfaces stored in a vault with a TSV registry.
+
+- `FieldVault` stores per-field `field.npz` + `records.tsv`.
+- `FieldRegistry` tracks kind/path/count/dirty/lineage.
+- `FieldLifecycleManager` ingests text, routes with taxonomy, fits/saves fields, and retrieves/reinforces.
+- Fields are auto-created on first use.
+- Dirty flags indicate refit/save needs.

--- a/docs/NOVAVEX_NEBULA_ORION_REBUILD_NOTES.md
+++ b/docs/NOVAVEX_NEBULA_ORION_REBUILD_NOTES.md
@@ -1,0 +1,10 @@
+# Rebuild Notes
+Rebuilt concepts:
+- FLEX: lifecycle orchestration, field creation/vaults, merge/fold operations.
+- FORGE: validation checks and report output.
+- STL: deterministic taxonomy routing.
+- Orion: episodic + semantic + procedural conversational memory split.
+- Nebula: living memory loop, registry bookkeeping, fold/compression concept.
+
+Intentionally excluded:
+- AiOS complexity, daemons, Kubernetes, GUI, emotional subsystems, heavy cloud model dependencies.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,3 +7,7 @@
 5. Conversational shell
 6. Optional tiny decoder
 7. Evaluation suite
+
+8. Continuous field lifecycle and conversational memory
+9. Field consolidation (merge/fold)
+10. ForgeLite validation and reporting

--- a/tests/test_consolidation.py
+++ b/tests/test_consolidation.py
@@ -1,0 +1,24 @@
+from virgo2.consolidation import FieldConsolidator
+from virgo2.memory import NeuralMemory
+from virgo2.registry import FieldRegistry
+from virgo2.vault import FieldVault
+
+
+def test_consolidation(tmp_path) -> None:
+    v = FieldVault(tmp_path)
+    r = FieldRegistry(tmp_path)
+    m = NeuralMemory()
+    for i in range(20):
+        m.add(f"item {i}", salience=3.0 if i < 2 else 0.5)
+    m.fit()
+    v.save("conversation_core", m)
+    r.register("conversation_core", "conversation", v.field_path("conversation_core"))
+    r.update_count("conversation_core", len(m.records))
+
+    c = FieldConsolidator(v, r)
+    merged = c.merge_fields(["conversation_core"], "merged")
+    assert len(merged.records) == 20
+    folded = c.fold_field("conversation_core", "folded", max_records=8)
+    assert len(folded.records) <= 9
+    assert any("item 0" in rec.text for rec in folded.records)
+    assert r.get("folded").folded_from == ["conversation_core"]

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,13 @@
+from virgo2.conversation import ConversationMemory
+from virgo2.lifecycle import FieldLifecycleManager
+from virgo2.registry import FieldRegistry
+from virgo2.vault import FieldVault
+
+
+def test_conversation_memory(tmp_path):
+    c = ConversationMemory(FieldLifecycleManager(FieldVault(tmp_path), FieldRegistry(tmp_path)))
+    c.add_turn("user", "hello")
+    c.add_turn("assistant", "hi")
+    c.converse_memory_update("Remember that my name is Nicholas")
+    ctx = c.context_for("what is my name")
+    assert "Relevant memory" in ctx and "Nicholas" in ctx

--- a/tests/test_forge.py
+++ b/tests/test_forge.py
@@ -1,0 +1,17 @@
+from virgo2.forge import ForgeLite
+from virgo2.lifecycle import FieldLifecycleManager
+from virgo2.registry import FieldRegistry
+from virgo2.vault import FieldVault
+
+
+def test_forge(tmp_path):
+    m = FieldLifecycleManager(FieldVault(tmp_path), FieldRegistry(tmp_path))
+    m.ingest("remember this fact")
+    m.registry.mark_dirty("conversation_core", True)
+    f = ForgeLite(m.vault, m.registry)
+    checks = f.run_checks()
+    assert isinstance(checks, dict)
+    assert "dirty_fields" in checks and checks["loadable_fields_count"] >= 1
+    report = tmp_path / "report.md"
+    f.write_report(report)
+    assert report.exists()

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,14 @@
+from virgo2.lifecycle import FieldLifecycleManager
+from virgo2.registry import FieldRegistry
+from virgo2.vault import FieldVault
+
+
+def test_lifecycle(tmp_path):
+    m = FieldLifecycleManager(FieldVault(tmp_path), FieldRegistry(tmp_path))
+    s = m.status()
+    assert "conversation_core" in s["registered_fields"]
+    m.ingest("my name is Nicholas")
+    out = m.retrieve("Nicholas")
+    assert out
+    m2 = FieldLifecycleManager(FieldVault(tmp_path), FieldRegistry(tmp_path))
+    assert m2.retrieve("Nicholas")

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,17 @@
+from virgo2.registry import FieldRegistry
+
+
+def test_registry_roundtrip(tmp_path) -> None:
+    r = FieldRegistry(tmp_path)
+    r.register("a", "semantic", tmp_path / "fields/a")
+    assert r.get("a") is not None
+    assert len(r.list()) == 1
+    r.mark_dirty("a", True)
+    r.update_count("a", 3)
+    r.set_folded_from("a", ["x", "y"])
+    r.save()
+
+    r2 = FieldRegistry(tmp_path)
+    r2.load()
+    a = r2.get("a")
+    assert a and a.dirty and a.record_count == 3 and a.folded_from == ["x", "y"]

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -1,0 +1,19 @@
+from virgo2.memory import NeuralMemory
+from virgo2.retrieval import MultiFieldRetriever
+
+
+def test_multi_field_retrieval() -> None:
+    a = NeuralMemory()
+    a.add("Virgo project memory", salience=2.0)
+    a.fit()
+
+    b = NeuralMemory()
+    b.add("Virgo project memory", salience=1.0)
+    b.add("other note")
+    b.fit()
+
+    out = MultiFieldRetriever({"a": a, "b": b}).search("Virgo", k=5)
+    assert out
+    assert out[0].rank == 1
+    texts = [x.record.text for x in out]
+    assert texts.count("Virgo project memory") == 1

--- a/tests/test_salience.py
+++ b/tests/test_salience.py
@@ -1,0 +1,9 @@
+from virgo2.salience import clamp_salience, decay_salience, estimate_salience, reinforce_salience
+
+
+def test_salience_behaviors():
+    assert estimate_salience("remember this") > estimate_salience("hello")
+    assert estimate_salience("hello", role="assistant") < estimate_salience("hello", role="user")
+    assert decay_salience(2.0, rate=0.5) < 2.0
+    assert reinforce_salience(1.0) > 1.0
+    assert clamp_salience(100.0) <= 5.0

--- a/tests/test_taxonomy.py
+++ b/tests/test_taxonomy.py
@@ -1,0 +1,9 @@
+from virgo2.taxonomy import SemanticTaxonomy
+
+
+def test_taxonomy_routes():
+    t = SemanticTaxonomy()
+    assert t.field_for("my name is Nicholas") == "identity_core"
+    assert t.field_for("Virgo-2 neural field project") == "project_core"
+    assert t.field_for("how to train the model") == "procedural_core"
+    assert t.field_for("hello there") in {"conversation_core", "semantic_core"}

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,0 +1,22 @@
+import pytest
+
+from virgo2.memory import NeuralMemory
+from virgo2.vault import FieldVault
+
+
+def test_vault_ops(tmp_path) -> None:
+    v = FieldVault(tmp_path)
+    assert v.field_path("conversation_core") == tmp_path / "fields" / "conversation_core"
+
+    m = NeuralMemory()
+    m.add("hello")
+    m.fit()
+    v.save("conversation_core", m)
+
+    assert "conversation_core" in v.list_field_names()
+    loaded = v.load("conversation_core")
+    assert loaded.records[0].text == "hello"
+    rep = v.integrity_report()
+    assert {"vault_path", "field_count", "missing_field_artifacts", "loadable_fields", "errors"} <= set(rep)
+    with pytest.raises(FileNotFoundError):
+        v.load("missing")

--- a/virgo2/__init__.py
+++ b/virgo2/__init__.py
@@ -1,7 +1,25 @@
 """Virgo-2 memory substrate plus experimental DDiF-inspired neural-field LM."""
 
+from .conversation import ConversationMemory, ConversationTurn
 from .coordinates import CoordinateEncoder
 from .field import NeuralField
+from .lifecycle import FieldLifecycleManager
 from .memory import MemoryRecord, NeuralMemory
+from .registry import FieldInfo, FieldRegistry
+from .retrieval import MultiFieldRetriever, RetrievedMemory
+from .vault import FieldVault
 
-__all__ = ["CoordinateEncoder", "NeuralField", "MemoryRecord", "NeuralMemory"]
+__all__ = [
+    "CoordinateEncoder",
+    "NeuralField",
+    "MemoryRecord",
+    "NeuralMemory",
+    "ConversationMemory",
+    "ConversationTurn",
+    "FieldLifecycleManager",
+    "FieldInfo",
+    "FieldRegistry",
+    "RetrievedMemory",
+    "MultiFieldRetriever",
+    "FieldVault",
+]

--- a/virgo2/cli.py
+++ b/virgo2/cli.py
@@ -4,10 +4,16 @@ import argparse
 from pathlib import Path
 
 from .browser_export import export_browser_bundle
+from .consolidation import FieldConsolidator
+from .conversation import ConversationMemory
 from .ddif import TextFieldDistiller
+from .forge import ForgeLite
+from .lifecycle import FieldLifecycleManager
 from .memory import NeuralMemory
 from .merge import merge_memories
+from .registry import FieldRegistry
 from .storage import load_memory, save_memory
+from .vault import FieldVault
 
 
 def _load_or_new(path: str) -> NeuralMemory:
@@ -17,60 +23,120 @@ def _load_or_new(path: str) -> NeuralMemory:
     return NeuralMemory()
 
 
+def _manager(vault_dir: str) -> FieldLifecycleManager:
+    return FieldLifecycleManager(vault=FieldVault(vault_dir), registry=FieldRegistry(vault_dir))
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(prog="virgo2")
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    ingest = sub.add_parser("ingest")
+    for cmd in ["ingest", "query", "add", "decay", "merge", "export-browser", "inspect"]:
+        sub.add_parser(cmd)
+    ingest = sub.choices["ingest"]
     ingest.add_argument("input_txt")
     ingest.add_argument("store_dir")
-
-    query = sub.add_parser("query")
+    query = sub.choices["query"]
     query.add_argument("store_dir")
     query.add_argument("query")
     query.add_argument("--k", type=int, default=5)
-
-    add = sub.add_parser("add")
+    add = sub.choices["add"]
     add.add_argument("store_dir")
     add.add_argument("text")
-
-    decay = sub.add_parser("decay")
+    decay = sub.choices["decay"]
     decay.add_argument("store_dir")
     decay.add_argument("--rate", type=float, default=0.01)
-
-    merge = sub.add_parser("merge")
+    merge = sub.choices["merge"]
     merge.add_argument("output_store")
     merge.add_argument("stores", nargs="+")
-
-    export = sub.add_parser("export-browser")
+    export = sub.choices["export-browser"]
     export.add_argument("store_dir")
     export.add_argument("output_dir")
-
-    inspect = sub.add_parser("inspect")
-    inspect.add_argument("store_dir")
+    sub.choices["inspect"].add_argument("store_dir")
 
     lm_train = sub.add_parser("lm-train")
     lm_train.add_argument("input_txt")
     lm_train.add_argument("model_dir")
     lm_train.add_argument("--epochs", type=int, default=200)
-
     lm_generate = sub.add_parser("lm-generate")
     lm_generate.add_argument("model_dir")
     lm_generate.add_argument("prompt")
     lm_generate.add_argument("--max-chars", type=int, default=200)
-
     ddif_reconstruct = sub.add_parser("ddif-reconstruct")
     ddif_reconstruct.add_argument("input_txt")
     ddif_reconstruct.add_argument("output_dir")
-
     ddif_sample = sub.add_parser("ddif-sample")
     ddif_sample.add_argument("output_dir")
     ddif_sample.add_argument("--prompt", default="hello")
     ddif_sample.add_argument("--max-chars", type=int, default=120)
 
-    args = parser.parse_args()
+    vault_init = sub.add_parser("vault-init")
+    vault_init.add_argument("vault_dir")
+    remember = sub.add_parser("remember")
+    remember.add_argument("vault_dir")
+    remember.add_argument("text")
+    remember.add_argument("--field", default=None)
+    recall = sub.add_parser("recall")
+    recall.add_argument("vault_dir")
+    recall.add_argument("query")
+    recall.add_argument("--k", type=int, default=8)
+    chat_memory = sub.add_parser("chat-memory")
+    chat_memory.add_argument("vault_dir")
+    chat_memory.add_argument("user_message")
+    fold = sub.add_parser("fold")
+    fold.add_argument("vault_dir")
+    fold.add_argument("source_field")
+    fold.add_argument("target_field")
+    fold.add_argument("--max-records", type=int, default=250)
+    merge_fields = sub.add_parser("merge-fields")
+    merge_fields.add_argument("vault_dir")
+    merge_fields.add_argument("target_field")
+    merge_fields.add_argument("source_fields", nargs="+")
+    forge_check = sub.add_parser("forge-check")
+    forge_check.add_argument("vault_dir")
+    forge_check.add_argument("--report", default=None)
 
-    if args.cmd == "ingest":
+    args = parser.parse_args()
+    if args.cmd == "vault-init":
+        m = _manager(args.vault_dir)
+        m.initialize_defaults()
+        m.save_all()
+        print(f"Vault initialized at {args.vault_dir}")
+    elif args.cmd == "remember":
+        m = _manager(args.vault_dir)
+        rec = m.ingest(args.text, field_name=args.field)
+        print(f"stored field={args.field or m.taxonomy.field_for(args.text)} salience={rec.salience:.3f}")
+    elif args.cmd == "recall":
+        m = _manager(args.vault_dir)
+        for r in m.retrieve(args.query, k=args.k):
+            print(f"{r.rank}. [{r.field_name}] score={r.score:.4f} text={r.record.text}")
+    elif args.cmd == "chat-memory":
+        m = _manager(args.vault_dir)
+        c = ConversationMemory(m)
+        c.converse_memory_update(args.user_message)
+        print(c.context_for(args.user_message))
+    elif args.cmd == "fold":
+        m = _manager(args.vault_dir)
+        out = FieldConsolidator(m.vault, m.registry).fold_field(
+            args.source_field,
+            args.target_field,
+            max_records=args.max_records,
+        )
+        m.registry.save()
+        print(f"folded to {args.target_field} records={len(out.records)}")
+    elif args.cmd == "merge-fields":
+        m = _manager(args.vault_dir)
+        out = FieldConsolidator(m.vault, m.registry).merge_fields(args.source_fields, args.target_field)
+        m.registry.save()
+        print(f"merged to {args.target_field} records={len(out.records)}")
+    elif args.cmd == "forge-check":
+        m = _manager(args.vault_dir)
+        forge = ForgeLite(m.vault, m.registry)
+        print(forge.run_checks())
+        if args.report:
+            forge.write_report(args.report)
+            print(f"report={args.report}")
+    elif args.cmd == "ingest":
         memory = NeuralMemory()
         for line in Path(args.input_txt).read_text(encoding="utf-8").splitlines():
             if line.strip():

--- a/virgo2/consolidation.py
+++ b/virgo2/consolidation.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from .memory import MemoryRecord, NeuralMemory
+from .registry import FieldRegistry
+from .vault import FieldVault
+
+
+class FieldConsolidator:
+    def __init__(self, vault: FieldVault, registry: FieldRegistry) -> None:
+        self.vault = vault
+        self.registry = registry
+
+    def merge_fields(self, source_names: list[str], target_name: str, preserve_sources: bool = True) -> NeuralMemory:
+        merged = NeuralMemory()
+        for name in source_names:
+            mem = self.vault.load(name)
+            for rec in mem.records:
+                merged.add(rec.text, metadata=rec.metadata, salience=rec.salience)
+        if merged.records:
+            merged.fit()
+        self.vault.save(target_name, merged)
+        info = self.registry.register(target_name, "folded", self.vault.field_path(target_name))
+        self.registry.update_count(target_name, len(merged.records))
+        self.registry.set_folded_from(info.name, source_names)
+        self.registry.mark_dirty(target_name, False)
+        if not preserve_sources:
+            pass
+        return merged
+
+    def fold_field(self, source_name: str, target_name: str, max_records: int = 250) -> NeuralMemory:
+        source = self.vault.load(source_name)
+        if len(source.records) <= max_records:
+            return self.merge_fields([source_name], target_name)
+        ranked = sorted(source.records, key=lambda r: r.salience, reverse=True)
+        keep_n = max(1, max_records // 2)
+        kept = ranked[:keep_n]
+        rest = ranked[keep_n:]
+        target = NeuralMemory()
+        for rec in kept:
+            target.add(rec.text, rec.metadata, rec.salience)
+        chunk_size = max(3, len(rest) // max(1, max_records - keep_n))
+        for i in range(0, len(rest), chunk_size):
+            target.add(**self.summarize_record_cluster(rest[i : i + chunk_size]).__dict__)
+        if target.records:
+            target.fit()
+        self.vault.save(target_name, target)
+        self.registry.register(target_name, "folded", self.vault.field_path(target_name))
+        self.registry.update_count(target_name, len(target.records))
+        self.registry.set_folded_from(target_name, [source_name])
+        return target
+
+    def summarize_record_cluster(self, records: list[MemoryRecord]) -> MemoryRecord:
+        if not records:
+            return MemoryRecord(text="Folded memory summary: (empty)", metadata={"folded": "true"}, salience=0.5)
+        text = "; ".join(r.text.strip() for r in records[:5])
+        salience = min(3.0, max(0.1, sum(r.salience for r in records) / len(records)))
+        return MemoryRecord(
+            text=f"Folded memory summary: {text}",
+            metadata={"folded": "true", "items": str(len(records))},
+            salience=salience,
+        )

--- a/virgo2/conversation.py
+++ b/virgo2/conversation.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from .lifecycle import FieldLifecycleManager
+
+
+@dataclass
+class ConversationTurn:
+    role: str
+    text: str
+    timestamp: str
+
+
+class ConversationMemory:
+    def __init__(self, lifecycle: FieldLifecycleManager) -> None:
+        self.lifecycle = lifecycle
+
+    def add_turn(self, role: str, text: str) -> ConversationTurn:
+        ts = datetime.now(timezone.utc).isoformat()
+        salience = 1.0 if role == "user" else 0.5
+        self.lifecycle.ingest(text, field_name="conversation_core", kind="conversation", metadata={"role": role, "timestamp": ts}, salience=salience)
+        return ConversationTurn(role=role, text=text, timestamp=ts)
+
+    def remember_fact(self, text: str, metadata: dict[str, str] | None = None, salience: float = 2.0) -> None:
+        self.lifecycle.ingest(text, field_name=self.lifecycle.taxonomy.field_for(text), kind=self.lifecycle.taxonomy.kind_for(text), metadata=metadata, salience=salience)
+
+    def context_for(self, user_message: str, k: int = 8) -> str:
+        found = self.lifecycle.retrieve(user_message, k=k)
+        if not found:
+            return "No relevant memory found."
+        lines = ["Relevant memory:"]
+        for m in found:
+            lines.append(f"- [{m.field_name} | {m.score:.3f}] {m.record.text}")
+        return "\n".join(lines)
+
+    def converse_memory_update(self, user_message: str, assistant_message: str | None = None) -> None:
+        self.add_turn("user", user_message)
+        t = user_message.lower()
+        if any(k in t for k in ["remember", "my name is", "i like", "i prefer", "i am working on", "the project is", "my goal is"]):
+            self.remember_fact(user_message, metadata={"source": "conversation"}, salience=2.5)
+        if assistant_message:
+            self.add_turn("assistant", assistant_message)

--- a/virgo2/forge.py
+++ b/virgo2/forge.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .registry import FieldRegistry
+from .vault import FieldVault
+
+
+class ForgeLite:
+    def __init__(self, vault: FieldVault, registry: FieldRegistry) -> None:
+        self.vault = vault
+        self.registry = registry
+
+    def run_checks(self) -> dict[str, object]:
+        self.registry.load()
+        report = self.vault.integrity_report()
+        dirty = [f.name for f in self.registry.list() if f.dirty]
+        oversized = [f.name for f in self.registry.list() if f.record_count > 500]
+        missing_paths = [f.name for f in self.registry.list() if not Path(f.path).exists()]
+        negative_salience: list[str] = []
+        loadable_count = 0
+        for f in self.registry.list():
+            if self.vault.exists(f.name):
+                mem = self.vault.load(f.name)
+                loadable_count += 1
+                if mem.records:
+                    _ = mem.retrieve("check", k=1)
+                for r in mem.records:
+                    if r.salience < 0:
+                        negative_salience.append(f.name)
+                        break
+        return {
+            "registry_loaded": True,
+            "vault_exists": self.vault.root.exists(),
+            "loadable_fields_count": loadable_count,
+            "dirty_fields": dirty,
+            "oversized_fields": oversized,
+            "missing_registered_paths": missing_paths,
+            "missing_field_artifacts": report["missing_field_artifacts"],
+            "errors": report["errors"],
+            "negative_salience_fields": negative_salience,
+        }
+
+    def write_report(self, path: str | Path) -> None:
+        checks = self.run_checks()
+        p = Path(path)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        lines = ["# ForgeLite Report", ""]
+        for k, v in checks.items():
+            lines.append(f"- {k}: {v}")
+        p.write_text("\n".join(lines), encoding="utf-8")

--- a/virgo2/lifecycle.py
+++ b/virgo2/lifecycle.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from .consolidation import FieldConsolidator
+from .memory import MemoryRecord, NeuralMemory
+from .registry import FieldRegistry
+from .retrieval import MultiFieldRetriever, RetrievedMemory
+from .salience import estimate_salience, reinforce_salience
+from .taxonomy import SemanticTaxonomy
+from .vault import FieldVault
+
+DEFAULT_FIELDS = {
+    "conversation_core": "conversation",
+    "semantic_core": "semantic",
+    "identity_core": "identity",
+    "project_core": "project",
+    "procedural_core": "procedural",
+}
+
+
+class FieldLifecycleManager:
+    def __init__(self, vault: FieldVault, registry: FieldRegistry | None = None, taxonomy: SemanticTaxonomy | None = None) -> None:
+        self.vault = vault
+        self.registry = registry or FieldRegistry(vault.root)
+        self.registry.load()
+        self.taxonomy = taxonomy or SemanticTaxonomy()
+        self.fields: dict[str, NeuralMemory] = {}
+        self.initialize_defaults()
+
+    def initialize_defaults(self) -> None:
+        for name, kind in DEFAULT_FIELDS.items():
+            self.ensure_field(name, kind)
+        self.registry.save()
+
+    def ensure_field(self, name: str, kind: str = "semantic") -> NeuralMemory:
+        if name in self.fields:
+            return self.fields[name]
+        mem = self.vault.load(name) if self.vault.exists(name) else self.vault.create_empty(name)
+        self.fields[name] = mem
+        self.registry.register(name, kind, self.vault.field_path(name))
+        self.registry.update_count(name, len(mem.records))
+        return mem
+
+    def ingest(self, text: str, field_name: str | None = None, kind: str | None = None, metadata: dict[str, str] | None = None, salience: float | None = None) -> MemoryRecord:
+        fname = field_name or self.taxonomy.field_for(text)
+        fkind = kind or self.taxonomy.kind_for(text)
+        mem = self.ensure_field(fname, fkind)
+        self.registry.mark_dirty(fname, True)
+        rec = mem.add(text, metadata=metadata, salience=salience if salience is not None else estimate_salience(text, metadata.get("role", "user") if metadata else "user"))
+        mem.fit()
+        self.vault.save(fname, mem)
+        self.registry.update_count(fname, len(mem.records))
+        self.registry.mark_dirty(fname, False)
+        self.registry.save()
+        return rec
+
+    def retrieve(self, query: str, k: int = 5, field_names: list[str] | None = None) -> list[RetrievedMemory]:
+        names = field_names or [f.name for f in self.registry.list()]
+        fields = {name: self.ensure_field(name, self.registry.get(name).kind if self.registry.get(name) else "semantic") for name in names}
+        out = MultiFieldRetriever(fields).search(query, k=k)
+        for item in out:
+            mem = self.fields[item.field_name]
+            idx = mem.records.index(item.record)
+            mem.update_salience(idx, reinforce_salience(mem.records[idx].salience))
+            mem.fit()
+            self.vault.save(item.field_name, mem)
+            self.registry.update_count(item.field_name, len(mem.records))
+        self.registry.save()
+        return out
+
+    def save_all(self) -> None:
+        for name, mem in self.fields.items():
+            self.vault.save(name, mem)
+            self.registry.update_count(name, len(mem.records))
+            self.registry.mark_dirty(name, False)
+        self.registry.save()
+
+    def load_all(self) -> None:
+        self.registry.load()
+        for info in self.registry.list():
+            if self.vault.exists(info.name):
+                self.fields[info.name] = self.vault.load(info.name)
+
+    def fold_if_needed(self, max_records_per_field: int = 500, target_prefix: str = "folded") -> list[str]:
+        consolidator = FieldConsolidator(self.vault, self.registry)
+        created: list[str] = []
+        for info in self.registry.list():
+            if info.record_count > max_records_per_field:
+                target = f"{target_prefix}_{info.name}"
+                consolidator.fold_field(info.name, target, max_records=max_records_per_field)
+                created.append(target)
+        self.registry.save()
+        return created
+
+    def status(self) -> dict[str, object]:
+        return {
+            "vault_path": str(self.vault.root),
+            "registered_fields": [f.name for f in self.registry.list()],
+            "loaded_fields": sorted(self.fields.keys()),
+            "record_counts": {f.name: f.record_count for f in self.registry.list()},
+            "dirty_fields": [f.name for f in self.registry.list() if f.dirty],
+        }

--- a/virgo2/registry.py
+++ b/virgo2/registry.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass
+class FieldInfo:
+    name: str
+    kind: str
+    path: str
+    record_count: int = 0
+    created_at: str = ""
+    updated_at: str = ""
+    dirty: bool = False
+    folded_from: list[str] | None = None
+
+
+class FieldRegistry:
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.path = self.root / "registry.tsv"
+        self._fields: dict[str, FieldInfo] = {}
+
+    def _now(self) -> str:
+        return datetime.now(timezone.utc).isoformat()
+
+    def register(self, name: str, kind: str, path: str | Path) -> FieldInfo:
+        p = str(Path(path))
+        now = self._now()
+        if name in self._fields:
+            f = self._fields[name]
+            f.kind = kind
+            f.path = p
+            f.updated_at = now
+            return f
+        info = FieldInfo(name=name, kind=kind, path=p, created_at=now, updated_at=now, folded_from=[])
+        self._fields[name] = info
+        return info
+
+    def get(self, name: str) -> FieldInfo | None:
+        return self._fields.get(name)
+
+    def list(self, kind: str | None = None) -> list[FieldInfo]:
+        vals = list(self._fields.values())
+        if kind is None:
+            return sorted(vals, key=lambda x: x.name)
+        return sorted([f for f in vals if f.kind == kind], key=lambda x: x.name)
+
+    def mark_dirty(self, name: str, dirty: bool = True) -> None:
+        f = self._fields[name]
+        f.dirty = dirty
+        f.updated_at = self._now()
+
+    def update_count(self, name: str, count: int) -> None:
+        f = self._fields[name]
+        f.record_count = int(count)
+        f.updated_at = self._now()
+
+    def set_folded_from(self, name: str, sources: list[str]) -> None:
+        f = self._fields[name]
+        f.folded_from = list(sources)
+        f.updated_at = self._now()
+
+    def save(self) -> None:
+        self.root.mkdir(parents=True, exist_ok=True)
+        with self.path.open("w", encoding="utf-8") as fh:
+            fh.write("name\tkind\tpath\trecord_count\tcreated_at\tupdated_at\tdirty\tfolded_from\n")
+            for f in self.list():
+                folded = ",".join(f.folded_from or [])
+                fh.write(
+                    f"{f.name}\t{f.kind}\t{f.path}\t{f.record_count}\t{f.created_at}\t{f.updated_at}\t{int(f.dirty)}\t{folded}\n"
+                )
+
+    def load(self) -> None:
+        self._fields = {}
+        if not self.path.exists():
+            return
+        with self.path.open("r", encoding="utf-8") as fh:
+            next(fh, None)
+            for line in fh:
+                name, kind, path, count, created, updated, dirty, folded = line.rstrip("\n").split("\t")
+                self._fields[name] = FieldInfo(
+                    name=name,
+                    kind=kind,
+                    path=path,
+                    record_count=int(count),
+                    created_at=created,
+                    updated_at=updated,
+                    dirty=dirty == "1",
+                    folded_from=[x for x in folded.split(",") if x] if folded else [],
+                )

--- a/virgo2/retrieval.py
+++ b/virgo2/retrieval.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .memory import MemoryRecord, NeuralMemory
+
+
+@dataclass
+class RetrievedMemory:
+    field_name: str
+    record: MemoryRecord
+    score: float
+    rank: int
+
+
+class MultiFieldRetriever:
+    def __init__(self, fields: dict[str, NeuralMemory]) -> None:
+        self.fields = fields
+
+    def search(self, query: str, k: int = 5) -> list[RetrievedMemory]:
+        gathered: list[tuple[str, MemoryRecord, float]] = []
+        for fname, mem in self.fields.items():
+            if not mem.records:
+                continue
+            for rec, score in mem.retrieve(query, k=max(k, 10)):
+                gathered.append((fname, rec, float(score)))
+        best_by_text: dict[str, tuple[str, MemoryRecord, float]] = {}
+        for fname, rec, score in gathered:
+            prev = best_by_text.get(rec.text)
+            if prev is None or score < prev[2]:
+                best_by_text[rec.text] = (fname, rec, score)
+        ordered = sorted(best_by_text.values(), key=lambda x: x[2])[: max(0, k)]
+        return [RetrievedMemory(field_name=f, record=r, score=s, rank=i + 1) for i, (f, r, s) in enumerate(ordered)]

--- a/virgo2/salience.py
+++ b/virgo2/salience.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SalienceConfig:
+    min_salience: float = 0.1
+    max_salience: float = 5.0
+    reinforce_step: float = 0.15
+
+
+def clamp_salience(value: float, min_salience: float = 0.1, max_salience: float = 5.0) -> float:
+    return max(min_salience, min(max_salience, float(value)))
+
+
+def estimate_salience(text: str, role: str = "user") -> float:
+    t = text.lower()
+    score = 1.0
+    strong = ["remember", "my name is", "i prefer", "i like", "goal", "important"]
+    project = ["project", "virgo", "neural field", "ddif", "architecture"]
+    if any(k in t for k in strong):
+        score += 1.0
+    if any(k in t for k in project):
+        score += 0.5
+    if role == "assistant":
+        score *= 0.6
+    return clamp_salience(score)
+
+
+def decay_salience(value: float, rate: float = 0.01) -> float:
+    if not 0 <= rate <= 1:
+        raise ValueError("rate must be between 0 and 1")
+    return clamp_salience(value * (1.0 - rate))
+
+
+def reinforce_salience(value: float, step: float = 0.15) -> float:
+    return clamp_salience(value + step)

--- a/virgo2/taxonomy.py
+++ b/virgo2/taxonomy.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+
+class SemanticTaxonomy:
+    def tags_for(self, text: str) -> list[str]:
+        t = text.lower()
+        tags: list[str] = []
+        if any(k in t for k in ["my name is", "i am", "i'm", "i like", "i prefer", "remember that i"]):
+            tags.append("identity")
+        if any(k in t for k in ["project", "virgo", "neural field", "ddif", "repository", "github", "code", "architecture"]):
+            tags.append("project")
+        if any(k in t for k in ["how to", "steps", "workflow", "process", "procedure"]):
+            tags.append("procedural")
+        if not tags:
+            tags.append("conversation")
+        return tags
+
+    def field_for(self, text: str) -> str:
+        tags = self.tags_for(text)
+        if "identity" in tags:
+            return "identity_core"
+        if "project" in tags:
+            return "project_core"
+        if "procedural" in tags:
+            return "procedural_core"
+        t = text.lower()
+        if any(x in t for x in ["fact", "is", "are", "was", "were"]):
+            return "semantic_core"
+        return "conversation_core"
+
+    def kind_for(self, text: str) -> str:
+        return self.field_for(text).replace("_core", "")

--- a/virgo2/vault.py
+++ b/virgo2/vault.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .memory import NeuralMemory
+from .storage import load_memory, save_memory
+
+
+class FieldVault:
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.fields_root = self.root / "fields"
+
+    def field_path(self, name: str) -> Path:
+        return self.fields_root / name
+
+    def exists(self, name: str) -> bool:
+        p = self.field_path(name)
+        return (p / "field.npz").exists() and (p / "records.tsv").exists()
+
+    def create_empty(self, name: str) -> NeuralMemory:
+        _ = self.field_path(name)
+        return NeuralMemory()
+
+    def save(self, name: str, memory: NeuralMemory) -> None:
+        save_memory(memory, self.field_path(name))
+
+    def load(self, name: str) -> NeuralMemory:
+        p = self.field_path(name)
+        if not self.exists(name):
+            raise FileNotFoundError(f"Field '{name}' not found at {p}")
+        return load_memory(p)
+
+    def list_field_names(self) -> list[str]:
+        if not self.fields_root.exists():
+            return []
+        names = [p.name for p in self.fields_root.iterdir() if p.is_dir()]
+        return sorted(names)
+
+    def integrity_report(self) -> dict[str, object]:
+        missing: list[str] = []
+        loadable: list[str] = []
+        errors: list[str] = []
+        names = self.list_field_names()
+        for name in names:
+            p = self.field_path(name)
+            if not (p / "field.npz").exists() or not (p / "records.tsv").exists():
+                missing.append(name)
+                continue
+            try:
+                _ = self.load(name)
+                loadable.append(name)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"{name}: {exc}")
+        return {
+            "vault_path": str(self.root),
+            "field_count": len(names),
+            "missing_field_artifacts": missing,
+            "loadable_fields": loadable,
+            "errors": errors,
+        }


### PR DESCRIPTION
### Motivation
- Provide a lightweight continuous memory layer so user turns are routed, stored, and retrievable across compact neural memory fields. 
- Enable automatic field creation, persistence, multi-field retrieval with reinforcement, deterministic folding/merging, and simple health validation without heavy ML/infra dependencies. 
- Keep the design deterministic, testable, and minimal to integrate with the existing neural-field substrate and LM layer. 

### Description
- Implemented vault-backed field storage and TSV registry persistence with `FieldVault` and `FieldRegistry`, using `registry.tsv` for durable bookkeeping. 
- Added deterministic `SemanticTaxonomy` for rule-based routing, `FieldLifecycleManager` to initialize defaults, ingest text, fit/save fields, retrieve with reinforcement, and field status/folding triggers. 
- Added multi-field retrieval (`MultiFieldRetriever` / `RetrievedMemory`) with cross-field deduplication and global ranking and lightweight salience utilities (`salience.py`) for estimate/decay/reinforce/clamp. 
- Implemented conversational memory (`ConversationMemory`) to add turns, promote extracted facts into identity/project/procedural fields, and produce readable context packs. 
- Added field consolidation (`FieldConsolidator`) supporting merges and deterministic fold summaries while preserving lineage, and `ForgeLite` for vault/registry/field health checks and report writing. 
- Exposed lifecycle CLI commands and updated package exports and docs; added `vault-init`, `remember`, `recall`, `chat-memory`, `fold`, `merge-fields`, and `forge-check` in `virgo2/cli.py`. 

### Testing
- Installed dev deps and ran static checks with `python -m pip install -e ".[dev]"` and `ruff check .`, both succeeded. 
- Ran the full test suite with `python -m pytest`, all tests passed (`29 passed`). 
- Performed a manual CLI smoke sequence including `virgo2 vault-init`, multiple `virgo2 remember` calls, `virgo2 recall`, `virgo2 chat-memory`, a `virgo2 fold` invocation, and `virgo2 forge-check --report`, which completed and produced expected outputs and a report file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1011403f848322869fc5b2236e0a1f)