### PR TITLE
docs: add final lifecycle audit run notes

### DIFF
--- a/docs/FINAL_AUDIT_2026-05-22.md
+++ b/docs/FINAL_AUDIT_2026-05-22.md
@@ -1,0 +1,18 @@
+# Virgo-2 Final Lifecycle Audit (2026-05-22)
+
+This audit pass verified that Virgo-2's field lifecycle, conversational memory flow,
+DDiF-inspired LM commands, and forge checks execute successfully on a CPU-first local setup.
+
+## Validation run
+
+- `python -m pip install -e ".[dev]"`
+- `ruff check .`
+- `python -m pytest`
+- Manual smoke flow for memory ingest/query, vault lifecycle commands, fold/forge checks, and LM train/generate.
+
+## Outcome
+
+- Lint checks passed.
+- Test suite passed.
+- Manual CLI smoke flow passed end-to-end.
+- No architecture migration or heavyweight dependencies were introduced.


### PR DESCRIPTION
### Motivation
- Add a compact, dated audit record capturing the final lifecycle validation steps and outcomes so there is a reproducible record of the verification run. 

### Description
- Add `docs/FINAL_AUDIT_2026-05-22.md` which documents the exact validation commands executed and summarizes the lint/test results; no functional code changes were made. 

### Testing
- Verified automated validation by running `python -m pip install -e ".[dev]"`, `ruff check .`, and `python -m pytest`, with `ruff` passing and `pytest` reporting `29 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1014cd6d708322b6c4d5cf0c1528f1)