### PR TITLE
Add final Virgo-2 verification results report

### DIFF
--- a/docs/VERIFICATION_RESULTS.md
+++ b/docs/VERIFICATION_RESULTS.md
@@ -1,0 +1,148 @@
+# Virgo-2 Verification Results
+
+## Verification Date
+
+2026-05-22 10:03:05 UTC
+
+## Summary
+
+PASSED WITH LIMITATIONS. All required automated checks, module import checks, and full CLI smoke flow completed successfully without command crashes.
+
+## Commands Run
+
+- `python -m pip install -e ".[dev]"`
+- `ruff check .`
+- `python -m pytest`
+- `virgo2 --help`
+- `python - <<'PY' ... importlib.import_module(...) ... PY` (module import verification)
+- `rm -rf ./tmp_vault ./tmp_memory ./tmp_browser_bundle ./tmp_char_lm ./tmp_ddif_field ./field.txt`
+- `printf "Virgo-2 is a neural-field language model experiment...." > field.txt`
+- `virgo2 ingest field.txt ./tmp_memory`
+- `virgo2 query ./tmp_memory "continuous memory field"`
+- `virgo2 inspect ./tmp_memory`
+- `virgo2 export-browser ./tmp_memory ./tmp_browser_bundle`
+- `virgo2 vault-init ./tmp_vault`
+- `virgo2 create-field ./tmp_vault project_notes field.txt --type project`
+- `virgo2 auto-remember ./tmp_vault "Remember that my name is Nicholas."`
+- `virgo2 auto-remember ./tmp_vault "Remember that Virgo-2 uses continuous neural fields."`
+- `virgo2 recall ./tmp_vault "What is Virgo-2?"`
+- `virgo2 process-message ./tmp_vault "I am working on neural field memory." --session-id test_session`
+- `virgo2 session-start ./tmp_vault --session-id test_session`
+- `virgo2 session-add ./tmp_vault test_session user "I am working on neural field memory."`
+- `virgo2 session-context ./tmp_vault test_session "What am I working on?"`
+- `virgo2 reflect ./tmp_vault session_test_session --auto-promote`
+- `virgo2 session-fold ./tmp_vault test_session`
+- `virgo2 maintenance-cycle ./tmp_vault --max-records 5`
+- `virgo2 forge-check ./tmp_vault --report ./tmp_vault/report.md`
+- `virgo2 lm-train field.txt ./tmp_char_lm --epochs 20`
+- `virgo2 lm-generate ./tmp_char_lm "Virgo" --max-chars 80`
+- `virgo2 ddif-reconstruct field.txt ./tmp_ddif_field`
+- `virgo2 ddif-sample ./tmp_ddif_field --prompt "Virgo" --max-chars 80`
+
+## Automated Test Results
+
+- **pip install**: PASS (`virgo2==0.2.0` editable install succeeded)
+- **ruff**: PASS (`All checks passed!`)
+- **pytest**: PASS (`31 passed`)
+- **virgo2 --help**: PASS (legacy + new command set rendered)
+
+## CLI Smoke Test Results
+
+- `virgo2 ingest field.txt ./tmp_memory` — **PASS** — ingested 4 records.
+- `virgo2 query ./tmp_memory "continuous memory field"` — **PASS** — returned ranked results.
+- `virgo2 inspect ./tmp_memory` — **PASS** — records=4, field fitted.
+- `virgo2 export-browser ./tmp_memory ./tmp_browser_bundle` — **PASS** — bundle exported.
+- `virgo2 vault-init ./tmp_vault` — **PASS** — vault initialized.
+- `virgo2 create-field ./tmp_vault project_notes field.txt --type project` — **PASS** — field created and validated.
+- `virgo2 auto-remember ...` (identity) — **PASS** — routed to `identity_core` with promotion.
+- `virgo2 auto-remember ...` (project) — **PASS** — routed to `project_core` with promotion.
+- `virgo2 recall ./tmp_vault "What is Virgo-2?"` — **PASS** — multi-field recall returned relevant results.
+- `virgo2 process-message ... --session-id test_session` — **PASS** — context + stored field + reflection output returned.
+- `virgo2 session-start ./tmp_vault --session-id test_session` — **PASS** — session overlay exists.
+- `virgo2 session-add ...` — **PASS** — turn stored and reflected.
+- `virgo2 session-context ...` — **PASS** — context retrieval returned relevant lines.
+- `virgo2 reflect ./tmp_vault session_test_session --auto-promote` — **PASS** — structured `ReflectionReport` printed.
+- `virgo2 session-fold ./tmp_vault test_session` — **PASS** — folded session field created.
+- `virgo2 maintenance-cycle ./tmp_vault --max-records 5` — **PASS** — reflection/folding actions completed without crash.
+- `virgo2 forge-check ./tmp_vault --report ./tmp_vault/report.md` — **PASS** — ForgeLite report written.
+- `virgo2 lm-train field.txt ./tmp_char_lm --epochs 20` — **PASS** — model persisted.
+- `virgo2 lm-generate ./tmp_char_lm "Virgo" --max-chars 80` — **PASS** — generation completed.
+- `virgo2 ddif-reconstruct field.txt ./tmp_ddif_field` — **PASS** — distilled field written.
+- `virgo2 ddif-sample ./tmp_ddif_field --prompt "Virgo" --max-chars 80` — **PASS** — sampling completed.
+
+## Module Verification
+
+- field_types — PASS (importable; normalization helpers available)
+- field_builder — PASS (importable; build request/result path active in smoke)
+- session — PASS (session overlay workflow succeeded)
+- conflict — PASS (importable; reflection reported deterministic duplicate conflict)
+- curriculum — PASS (importable; CLI commands present)
+- reflection — PASS (structured report emitted)
+- registry — PASS (versioned TSV read/write path active)
+- vault — PASS (vault init/load used repeatedly)
+- lifecycle — PASS (`ingest_auto`, `fit_pending`, `maintenance_cycle` exercised)
+- consolidation — PASS (folding and compression updates executed)
+- forge — PASS (recall/roundtrip/latency/lineage/recommendations reported)
+- conversation — PASS (`process-message` successful)
+- taxonomy — PASS (importable)
+- cli — PASS (legacy + new commands available)
+- __init__ — PASS (explicit `__all__` list)
+
+## Registry Verification
+
+- Registry versioning status: PASS (`registry_version` field present in schema and row load logic).
+- TSV escaping status: PASS (registry uses escaped TSV serialization/deserialization path).
+- Legacy registry compatibility: PASS (loader assigns default version for legacy rows).
+- Schema migration behavior: PASS (missing/new columns handled with defaults in parser).
+
+## Lifecycle Verification
+
+- `ingest_auto` behavior: PASS (auto-routed memories to typed core fields).
+- `fit_pending` behavior: PASS (tracked by lifecycle and cleared during fit pass in maintenance cycle).
+- `maintenance_cycle` behavior: PASS (no crash; reports + folds + recommendations returned).
+- Retrieval reinforcement behavior: PASS at smoke level (retrieval path functioned with deterministic ranking and no retrain side effects observed).
+- Folding trigger behavior: PASS (session fold and auto-fold actions observed when thresholds met).
+
+## Reflection Verification
+
+- Repeated theme extraction: PASS (`repeated_themes` returned tokens like working/neural/field/memory).
+- Stable fact extraction: PASS (`promoted_facts` populated from repeated user memory).
+- Promotion behavior: PASS (`actions_taken` includes `promoted_facts`).
+- Conflict reporting: PASS (`conflicts` included `normalized_duplicate`).
+- Fold suggestion behavior: PASS (`suggested_folds` field present; auto-fold invoked via maintenance/session flow).
+
+## Consolidation Verification
+
+- Duplicate detection: PASS (duplicate surfaced in reflection conflict output).
+- Overlap detection: PASS at smoke level (field fold/merge operations completed without conflict).
+- Semantic clustering: PASS at smoke level (consolidation pipeline executed via maintenance flow).
+- High-salience preservation: PASS at smoke level (important facts remained recallable after fold).
+- Deterministic summaries: PASS at smoke level (repeatable deterministic outputs in this run).
+- Lineage tracking: PASS (ForgeLite lineage_valid true).
+- Compression ratio semantics: PASS (`compression_ratio` implementation reflects source_count / folded_count).
+
+## ForgeLite Verification
+
+- Recall validation: PASS (per-field recall stats included).
+- Roundtrip validation: PASS (all listed fields roundtrip true).
+- Latency benchmark separation: PASS (load/retrieval/total latency fields included).
+- Lineage validation: PASS (`lineage_valid: True`, no invalid entries).
+- Maintenance recommendations: PASS (`recommended_maintenance_actions` included).
+
+## Fixes Applied
+
+No fixes were required during this verification pass.
+
+## Remaining Limitations
+
+- Taxonomy remains heuristic-based.
+- Reflection is deterministic and simple.
+- Neural-field LM remains experimental.
+- Consolidation summaries are deterministic and pipeline-based, not semantic LLM summaries.
+- This pass is smoke/integration-level verification, not exhaustive production certification.
+
+## Final Status
+
+PASSED WITH LIMITATIONS
+
+Virgo-2 is ready for the next milestone with current architecture intact; verification confirms command surface, lifecycle wiring, registry compatibility, reflection/consolidation behavior, and ForgeLite reporting are functioning in this environment.


### PR DESCRIPTION
### Motivation

- Provide an authoritative, reproducible record of the final verification pass for the Virgo-2 milestone. 
- Capture commands run, automated test outcomes, CLI smoke flow results, module verifications, subsystem checks, and known limitations.
- Ensure the repository contains a machine-readable human-facing artifact (`docs/VERIFICATION_RESULTS.md`) for release and audit purposes.

### Description

- Added `docs/VERIFICATION_RESULTS.md` containing the full verification report with verification date, commands run, automated test results, CLI smoke test outcomes, module-by-module checks, registry/lifecycle/reflection/consolidation/ForgeLite verification, fixes applied, remaining limitations, and final status. 
- The report documents the exact commands executed during the pass including `python -m pip install -e ".[dev]"`, `ruff check .`, `python -m pytest`, `virgo2 --help`, an import verification script, and the complete CLI smoke sequence. 
- No functional code changes were made to core modules; this PR only adds the verification artifact and documents the environment outcomes. 
- The report explicitly records that no fixes were required during this pass and lists remaining limitations for future work.

### Testing

- Performed editable install with `python -m pip install -e ".[dev]"` which completed successfully and installed `virgo2==0.2.0` in editable mode. 
- Ran linting with `ruff check .` which reported `All checks passed!`. 
- Executed test suite with `python -m pytest` which reported `31 passed`. 
- Verified CLI help with `virgo2 --help` and ran an import verification using `importlib.import_module(...)`, both of which succeeded. 
- Executed the full CLI smoke flow (ingest/query/inspect/export/vault-init/create-field/auto-remember/recall/process-message/session operations/reflect/fold/maintenance/forge-check/lm-train/lm-generate/ddif-reconstruct/ddif-sample) and recorded pass/fail and outputs in the report; all smoke commands completed without crashes in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10295bbf388322ac4d220caf73c5cc)