### PR TITLE
Harden release readiness: deterministic taxonomy/reflection, registry/forge checks, CLI, docs & tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+## 0.9.0
+### Added
+- Release-check surfaces for lifecycle and ForgeLite.
+- Registry validation API and CLI access.
+
+### Changed
+- Deterministic weighted taxonomy classification with confidence and multi-tags.
+- Reflection report expanded with deterministic counters and serialization.
+
+### Fixed
+- Reflection duplicate promotion guard.
+- Registry malformed row tracking.
+
+### Verified
+- Lint, pytest, and CLI smoke workflows.
+
+### Known Limitations
+- Experimental neural-field LM remains non-production.
+- Deterministic consolidation is not LLM semantic summarization.

--- a/README.md
+++ b/README.md
@@ -1,134 +1,24 @@
 # Virgo-2
 
-Virgo-2 is a focused neural-field memory and language modeling research project. It treats memory as a continuous function over coordinates instead of only as discrete token embeddings, and layers lifecycle management plus lightweight conversational memory on top.
+Virgo-2 is a stable local neural-field memory substrate with deterministic lifecycle automation, reflection hygiene, consolidation, and release validation tooling.
 
-## What Virgo-2 is
+## What it is not
+- Not a cloud service
+- Not an autonomous daemon/OS
+- Not a full semantic reasoning AGI
 
-- A **core neural-field memory substrate** (`NeuralMemory`) with salience-weighted records and continuous retrieval.
-- A **field lifecycle + conversational memory layer** (`FieldLifecycleManager`, `ConversationMemory`, `FieldVault`, `FieldRegistry`) for routing, persistence, reinforcement, and folding.
-- An **experimental DDiF-inspired neural-field LM** for tiny text distillation and generation experiments.
+## Stable feature set
+- Vault/registry persistence with versioned metadata
+- Deterministic taxonomy routing and reflection
+- Lifecycle maintenance and deferred fitting
+- Folding/consolidation with lineage tracking
+- ForgeLite release-readiness checks
 
-## What Virgo-2 is not
+## Quickstart
+`virgo2 --help`
 
-- Not GPT-class model infrastructure.
-- Not production AGI, autonomous agent platform, or cloud-scale serving stack.
-- Not dependent on heavy mandatory components like FAISS, sentence-transformers, or hosted APIs.
-- Not a GUI or Kubernetes/daemon-based platform.
-
-## Why neural fields matter
-
-Neural fields provide a compact, continuous representation where nearby coordinates can produce semantically related values. In Virgo-2 this supports:
-
-- smooth interpolation over memory space,
-- salience-aware retrieval and reinforcement,
-- portable storage (`field.npz` + `records.tsv`) that stays lightweight.
-
-## Three-layer architecture
-
-1. **Core substrate**: `CoordinateEncoder`, `NeuralField`, `NeuralMemory`.
-2. **Lifecycle + conversation**: taxonomy routing, vault persistence, registry metadata, multi-field retrieval, salience reinforcement, and consolidation/folding.
-3. **DDiF-inspired LM**: character-level coordinate mapping and tiny generation loop for experimental language modeling.
-
-For deeper details see `docs/ARCHITECTURE.md` and layer-specific docs in `docs/`.
-
-## CLI quickstart
-
-```bash
-python -m pip install -e ".[dev]"
-
-virgo2 ingest sample.txt ./tmp_memory
-virgo2 query ./tmp_memory "continuous memory field" --k 5
-virgo2 export-browser ./tmp_memory ./tmp_browser_bundle
-
-virgo2 vault-init ./tmp_vault
-virgo2 remember ./tmp_vault "Remember that Virgo-2 is a neural-field language model project."
-virgo2 recall ./tmp_vault "What is Virgo-2?"
-virgo2 chat-memory ./tmp_vault "Do you remember what I am building?"
-
-virgo2 fold ./tmp_vault conversation_core folded_conversation_0001 --max-records 5
-virgo2 forge-check ./tmp_vault --report ./tmp_vault/report.md
-
-virgo2 lm-train tiny_lm.txt ./tmp_char_lm --epochs 20
-virgo2 lm-generate ./tmp_char_lm "hello" --max-chars 40
-```
-
-## Python usage examples
-
-### Core memory substrate
-
-```python
-from virgo2 import NeuralMemory
-
-memory = NeuralMemory()
-memory.add("Neural fields store memory as continuous functions.")
-memory.add("Virgo-2 is a research-grade system.")
-memory.fit()
-
-results = memory.retrieve("continuous memory", k=3)
-for record, score in results:
-    print(score, record.text)
-```
-
-### Vault + lifecycle example
-
-```python
-from virgo2 import FieldLifecycleManager, FieldRegistry, FieldVault
-
-vault = FieldVault("./tmp_vault")
-registry = FieldRegistry("./tmp_vault")
-manager = FieldLifecycleManager(vault=vault, registry=registry)
-
-manager.initialize_defaults()
-manager.ingest("Remember that my name is Nicholas.")
-manager.ingest("Virgo-2 is a neural-field LM experiment.")
-
-hits = manager.retrieve("What is Virgo-2?", k=5)
-for hit in hits:
-    print(hit.field_name, hit.score, hit.record.text)
-```
-
-### Field folding example
-
-```python
-from virgo2.consolidation import FieldConsolidator
-
-consolidator = FieldConsolidator(vault, registry)
-consolidator.fold_field("conversation_core", "folded_conversation_0001", max_records=250)
-registry.save()
-```
-
-### ForgeLite validation example
-
-```python
-from virgo2.forge import ForgeLite
-
-forge = ForgeLite(vault, registry)
-report = forge.run_checks()
-print(report)
-forge.write_report("./tmp_vault/report.md")
-```
-
-### Browser export example
-
-```python
-from virgo2.browser_export import export_browser_bundle
-from virgo2.storage import load_memory
-
-memory = load_memory("./tmp_memory")
-export_browser_bundle(memory, "./tmp_browser_bundle")
-```
+## Release status
+Targeted stable pre-1.0 release (`0.9.0`) with documented limitations.
 
 ## Limitations
-
-- Virgo-2 is not GPT-class in reasoning or generation quality.
-- The DDiF-inspired LM is early-stage and character-level.
-- Field folding is deterministic/simple summarization, not learned compression.
-- Memory lifecycle is functional but still research-grade.
-
-## Roadmap
-
-See `docs/ROADMAP.md` for concrete milestones around:
-
-- stronger retrieval scoring and field health metrics,
-- smarter consolidation and optional neural compression,
-- improved LM training/evaluation and prompt-conditioning.
+Neural-field LM is experimental; reflection/consolidation are deterministic and non-LLM.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,5 @@
+# API Reference
+Public API is exported via `virgo2.__all__` and includes memory, lifecycle, registry/vault, consolidation, taxonomy, reflection, conflict, session, curriculum, and ForgeLite validation classes.
+
+## CLI Commands
+Includes legacy commands plus: `status`, `release-check`, `registry-validate`, `taxonomy-classify`.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,9 @@
+# Operations
+- Initialize: `virgo2 vault-init <vault_dir>`
+- Ingest/retrieve: `virgo2 auto-remember`, `virgo2 recall`
+- Session overlays: `session-start`, `session-add`, `session-context`, `session-fold`
+- Reflection: `virgo2 reflect`
+- Maintenance: `virgo2 maintenance-cycle`
+- Folding: `virgo2 fold`
+- Registry validation: `virgo2 registry-validate`
+- Release checks: `virgo2 release-check`

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,9 @@
+# Release Checklist
+- Run `ruff check .`
+- Run `python -m pytest`
+- Run CLI smoke tests (`virgo2 --help`, status/release-check/registry-validate/taxonomy-classify)
+- Run `virgo2 release-check <vault_dir>`
+- Run `virgo2 registry-validate <vault_dir>`
+- Verify package metadata/version
+- Update CHANGELOG
+- Ensure no temp artifacts are committed

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -23,3 +23,6 @@
 - Evaluate unified memory+LM coupling where field memories condition generation.
 - Compare deterministic fold vs learned compression under retrieval-quality budgets.
 - Document empirical findings with reproducible experiment cards.
+
+
+Updated for stable-release hardening pass (0.9.0 target).

--- a/docs/STABLE_RELEASE_PLAN.md
+++ b/docs/STABLE_RELEASE_PLAN.md
@@ -1,0 +1,15 @@
+# Stable Release Plan
+
+Experimental exit required API stabilization, deterministic taxonomy/reflection hardening, registry validation, lifecycle/ForgeLite release checks, and CLI release ops.
+
+## Hardened
+- Explicit public API exports.
+- Weighted deterministic taxonomy classification.
+- Reflection report serialization and deduplicated promotion.
+- Lifecycle deferred fit + release readiness checks.
+- Registry malformed row reporting + validation.
+- ForgeLite release-check evaluator.
+
+## Remaining Post-Stable
+- Neural-field LM remains experimental.
+- Consolidation summaries remain deterministic pipeline summaries.

--- a/docs/STABLE_RELEASE_RESULTS.md
+++ b/docs/STABLE_RELEASE_RESULTS.md
@@ -1,0 +1,40 @@
+# Virgo-2 Stable Release Results
+
+## Summary
+PASSED WITH LIMITATIONS
+
+## Version Decision
+0.9.0 due to remaining known limitations before 1.0.0 (experimental neural-field LM and deterministic non-LLM summarization).
+
+## Commands Run
+- python -m pip install -e ".[dev]"
+- ruff check .
+- python -m pytest
+- virgo2 --help
+- virgo2 vault-init /tmp/virgo2-smoke
+- virgo2 status /tmp/virgo2-smoke
+- virgo2 taxonomy-classify "my name is alex"
+- virgo2 registry-validate /tmp/virgo2-smoke
+- virgo2 release-check /tmp/virgo2-smoke
+
+## Test Results
+See command outputs from lint and pytest.
+
+## CLI Smoke Results
+All release CLI commands executed successfully.
+
+## Release Check Results
+Release-check command produced readiness dict.
+
+## Registry Validation Results
+Registry validation command produced validation dict.
+
+## Public API Verification
+Verified public exports import through `from virgo2 import *` coverage test.
+
+## Limitations Remaining
+- Experimental neural-field LM
+- Deterministic, non-LLM consolidation summaries
+
+## Final Recommendation
+Ready for 0.9.0 tag; promote to 1.0.0 after remaining limitations are reduced.

--- a/docs/VERIFICATION_RESULTS.md
+++ b/docs/VERIFICATION_RESULTS.md
@@ -146,3 +146,6 @@ No fixes were required during this verification pass.
 PASSED WITH LIMITATIONS
 
 Virgo-2 is ready for the next milestone with current architecture intact; verification confirms command surface, lifecycle wiring, registry compatibility, reflection/consolidation behavior, and ForgeLite reporting are functioning in this environment.
+
+
+Updated for stable-release hardening pass (0.9.0 target).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "virgo2"
-version = "0.2.0"
+version = "0.9.0"
 description = "Neural-field memory substrate with experimental DDiF-inspired language modeling"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,13 @@
+from virgo2 import *  # noqa: F403
+
+
+def test_public_imports_present():
+    expected = [
+        "CoordinateEncoder","NeuralField","MemoryRecord","NeuralMemory","ConversationMemory","ConversationTurn",
+        "FieldLifecycleManager","FieldInfo","FieldRegistry","RetrievedMemory","MultiFieldRetriever","FieldVault",
+        "FieldConsolidator","SemanticTaxonomy","ForgeLite","FieldType","ResolutionLevel","normalize_field_type",
+        "normalize_resolution_level","FieldBuilder","FieldBuildRequest","FieldBuildResult","SessionOverlay","SessionInfo",
+        "Conflict","ConflictPolicy","FieldConflictResolver","CurriculumItem","CurriculumQueue","ReflectionEngine","ReflectionReport",
+    ]
+    for name in expected:
+        assert name in globals()

--- a/tests/test_reflection.py
+++ b/tests/test_reflection.py
@@ -1,0 +1,14 @@
+from virgo2.lifecycle import FieldLifecycleManager
+from virgo2.registry import FieldRegistry
+from virgo2.vault import FieldVault
+
+
+def test_reflection_report_and_determinism(tmp_path):
+    manager = FieldLifecycleManager(FieldVault(tmp_path), FieldRegistry(tmp_path))
+    manager.ingest("my name is Alex")
+    manager.ingest("my name is Alex")
+    report1 = manager.reflection_engine.reflect_on_field("identity_core", auto_promote=False, auto_fold=False)
+    report2 = manager.reflection_engine.reflect_on_field("identity_core", auto_promote=False, auto_fold=False)
+    assert report1.to_dict() == report2.to_dict()
+    assert report1.inspected_record_count >= 2
+    assert report1.promoted_count == 0

--- a/virgo2/cli.py
+++ b/virgo2/cli.py
@@ -171,6 +171,19 @@ def main() -> None:
     curriculum_next.add_argument("vault_dir")
     curriculum_next.add_argument("--batch-size", type=int, default=10)
 
+    status_cmd = sub.add_parser("status")
+    status_cmd.add_argument("vault_dir")
+
+    release_check = sub.add_parser("release-check")
+    release_check.add_argument("vault_dir")
+    release_check.add_argument("--report", default=None)
+
+    registry_validate = sub.add_parser("registry-validate")
+    registry_validate.add_argument("vault_dir")
+
+    taxonomy_classify = sub.add_parser("taxonomy-classify")
+    taxonomy_classify.add_argument("text")
+
     args = parser.parse_args()
 
     if args.cmd == "vault-init":
@@ -302,6 +315,25 @@ def main() -> None:
         queue = CurriculumQueue(Path(args.vault_dir) / "curriculum.tsv")
         queue.load()
         print(queue.next_batch(batch_size=args.batch_size))
+    elif args.cmd == "status":
+        manager = _manager(args.vault_dir)
+        print(manager.status())
+    elif args.cmd == "release-check":
+        manager = _manager(args.vault_dir)
+        forge = ForgeLite(manager.vault, manager.registry)
+        result = forge.release_check()
+        print(result)
+        if args.report:
+            Path(args.report).write_text("# Virgo-2 Release Check\n\n" + str(result), encoding="utf-8")
+            print(f"report={args.report}")
+    elif args.cmd == "registry-validate":
+        manager = _manager(args.vault_dir)
+        print(manager.registry.validate())
+    elif args.cmd == "taxonomy-classify":
+        from dataclasses import asdict
+        from .taxonomy import SemanticTaxonomy
+
+        print(asdict(SemanticTaxonomy().classify(args.text)))
 
 
 if __name__ == "__main__":

--- a/virgo2/forge.py
+++ b/virgo2/forge.py
@@ -99,3 +99,35 @@ class ForgeLite:
         for key, value in checks.items():
             lines.append(f"- {key}: {value}")
         p.write_text("\n".join(lines), encoding="utf-8")
+
+
+    def release_check(self) -> dict[str, object]:
+        checks = self.run_checks()
+        blocking: list[str] = []
+        warnings: list[str] = []
+        if checks["errors"]:
+            blocking.append("registry cannot load")
+        if checks["missing_registered_paths"]:
+            blocking.append("missing field artifacts")
+        if not checks["lineage"]["lineage_valid"]:
+            blocking.append("invalid folded lineage")
+        if any(not ok for ok in checks["roundtrip"]["roundtrip"].values()):
+            blocking.append("failed roundtrip")
+
+        for field in checks["empty_fields"]:
+            warnings.append(f"empty field: {field}")
+        for field in checks["dirty_fields"]:
+            warnings.append(f"dirty field: {field}")
+        for field in checks["oversized_fields"]:
+            warnings.append(f"oversized field: {field}")
+        if checks["latency"]["total_latency_ms"] > 1000:
+            warnings.append("high latency")
+        if checks["recommended_maintenance_actions"] != ["none"]:
+            warnings.append("maintenance recommended")
+
+        return {
+            "ready": not blocking,
+            "blocking_issues": blocking,
+            "warnings": warnings,
+            "checks": checks,
+        }

--- a/virgo2/lifecycle.py
+++ b/virgo2/lifecycle.py
@@ -151,12 +151,33 @@ class FieldLifecycleManager:
                 self.fields[info.name] = self.vault.load(info.name)
 
     def status(self) -> dict[str, object]:
+        infos = self.registry.list()
         return {
             "vault_path": str(self.vault.root),
-            "registered_fields": [f.name for f in self.registry.list()],
+            "registry_path": str(self.registry.path),
+            "registered_fields": [f.name for f in infos],
+            "field_count": len(infos),
             "loaded_fields": sorted(self.fields.keys()),
-            "record_counts": {f.name: f.record_count for f in self.registry.list()},
-            "dirty_fields": [f.name for f in self.registry.list() if f.dirty],
+            "record_counts": {f.name: f.record_count for f in infos},
+            "dirty_fields": [f.name for f in infos if f.dirty],
             "fit_pending": sorted(self.fit_pending),
             "maintenance_needed": sorted(self.maintenance_needed),
+        }
+
+    def release_check(self) -> dict[str, object]:
+        self.registry.load()
+        infos = self.registry.list()
+        dirty_fields = [f.name for f in infos if f.dirty]
+        oversized = [f.name for f in infos if f.record_count > 500]
+        lineage_invalid = [f.name for f in infos if f.kind == "folded" and not (f.parent_fields or f.folded_from)]
+        ready = not dirty_fields and not self.fit_pending and not self.maintenance_needed and not lineage_invalid
+        return {
+            "registry_loaded": True,
+            "field_count": len(infos),
+            "dirty_fields": dirty_fields,
+            "fit_pending": sorted(self.fit_pending),
+            "maintenance_needed": sorted(self.maintenance_needed),
+            "oversized_fields": oversized,
+            "fold_lineage_invalid": lineage_invalid,
+            "ready": ready,
         }

--- a/virgo2/reflection.py
+++ b/virgo2/reflection.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 from .conflict import FieldConflictResolver
 from .memory import MemoryRecord
@@ -16,6 +16,13 @@ class ReflectionReport:
     suggested_folds: list[str]
     conflicts: list[str]
     actions_taken: list[str]
+    inspected_record_count: int
+    promoted_count: int
+    conflict_count: int
+    suggested_fold_count: int
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
 
 
 class ReflectionEngine:
@@ -33,41 +40,57 @@ class ReflectionEngine:
                 if token not in self.STOP and len(token) > 2:
                     tokens.append(token)
         counts = Counter(tokens)
-        return [word for word, count in counts.most_common(8) if count > 1]
+        return sorted([word for word, count in counts.items() if count > 1])
 
     def extract_stable_facts(self, records: list[MemoryRecord]) -> list[str]:
         keys = ["remember that", "my name is", "i am", "i'm", "i like", "i prefer", "my goal is", "the project is", "i am working on"]
-        return [record.text.strip() for record in records if any(key in record.text.lower() for key in keys)]
+        facts = [record.text.strip() for record in records if any(key in record.text.lower() for key in keys)]
+        return sorted(set(facts))
 
     def promote_stable_facts(self, facts: list[str], source_field: str) -> list[str]:
+        promoted: list[str] = []
         for fact in facts:
-            self.lifecycle.ingest_auto(fact, metadata={"source_field": source_field}, run_reflection=False)
-        return facts
-
-    def suggest_folds(self, max_records: int = 500) -> list[str]:
-        return [field.name for field in self.lifecycle.registry.list() if field.record_count > max_records]
+            destination = self.lifecycle.taxonomy.field_for(fact)
+            destination_kind = self.lifecycle.taxonomy.kind_for(fact)
+            destination_memory = self.lifecycle.ensure_field(destination, destination_kind)
+            if any(record.text.strip() == fact for record in destination_memory.records):
+                continue
+            self.lifecycle.ingest(fact, field_name=destination, kind=destination_kind, metadata={"source_field": source_field})
+            promoted.append(fact)
+        return promoted
 
     def reflect_on_field(self, field_name: str, auto_promote: bool = True, auto_fold: bool = False, max_records_before_fold: int = 500) -> ReflectionReport:
         info = self.lifecycle.registry.get(field_name)
         kind = info.kind if info else "text"
         memory = self.lifecycle.ensure_field(field_name, kind)
-
         themes = self.extract_repeated_themes(memory.records)
         facts = self.extract_stable_facts(memory.records)
-        conflicts = [c.reason for c in self.conflict_resolver.detect_conflicts(memory.records)]
-
+        conflicts = sorted({c.reason for c in self.conflict_resolver.detect_conflicts(memory.records)})
         actions: list[str] = []
         promoted: list[str] = []
+
         if auto_promote and facts:
             promoted = self.promote_stable_facts(facts, field_name)
-            actions.append("promoted_facts")
+            if promoted:
+                actions.append("promoted_facts")
 
         folds = [field_name] if len(memory.records) > max_records_before_fold else []
         if auto_fold and folds:
             self.lifecycle.fold_if_needed(max_records_per_field=max_records_before_fold)
             actions.append("auto_fold")
 
-        return ReflectionReport(field_name, themes, promoted, folds, conflicts, actions)
+        return ReflectionReport(
+            source_field=field_name,
+            repeated_themes=themes,
+            promoted_facts=promoted,
+            suggested_folds=folds,
+            conflicts=conflicts,
+            actions_taken=actions,
+            inspected_record_count=len(memory.records),
+            promoted_count=len(promoted),
+            conflict_count=len(conflicts),
+            suggested_fold_count=len(folds),
+        )
 
     def reflect_on_recent_session(self, session_field: str, auto_promote: bool = True, auto_fold_session: bool = True) -> ReflectionReport:
         return self.reflect_on_field(session_field, auto_promote=auto_promote, auto_fold=auto_fold_session, max_records_before_fold=50)
@@ -75,12 +98,5 @@ class ReflectionEngine:
     def run_maintenance_cycle(self, max_records_before_fold: int = 500, auto_fold: bool = True) -> list[ReflectionReport]:
         reports: list[ReflectionReport] = []
         for field in self.lifecycle.registry.list():
-            reports.append(
-                self.reflect_on_field(
-                    field.name,
-                    auto_promote=True,
-                    auto_fold=auto_fold,
-                    max_records_before_fold=max_records_before_fold,
-                )
-            )
+            reports.append(self.reflect_on_field(field.name, auto_promote=True, auto_fold=auto_fold, max_records_before_fold=max_records_before_fold))
         return reports

--- a/virgo2/registry.py
+++ b/virgo2/registry.py
@@ -60,6 +60,7 @@ class FieldRegistry:
         self.root = Path(root)
         self.path = self.root / "registry.tsv"
         self._fields: dict[str, FieldInfo] = {}
+        self.malformed_rows: list[str] = []
 
     def _now(self) -> str:
         return datetime.now(timezone.utc).isoformat()
@@ -186,6 +187,7 @@ class FieldRegistry:
 
     def load(self) -> None:
         self._fields = {}
+        self.malformed_rows = []
         if not self.path.exists():
             return
         with self.path.open("r", encoding="utf-8") as fh:
@@ -193,11 +195,40 @@ class FieldRegistry:
             for line in fh:
                 cols = [self._unescape(x) for x in line.rstrip("\n").split("\t")]
                 if len(cols) != len(header):
+                    self.malformed_rows.append(line.rstrip("\n"))
                     continue
                 data = dict(zip(header, cols, strict=False))
                 if header == LEGACY_HEADER:
                     data["registry_version"] = "1"
                 name = data.get("name", "")
                 if not name:
+                    self.malformed_rows.append(line.rstrip("\n"))
                     continue
                 self._fields[name] = self._from_data(data)
+
+    def validate(self) -> dict[str, object]:
+        duplicates: list[str] = []
+        missing_paths: list[str] = []
+        invalid_resolution_levels: list[str] = []
+        errors: list[str] = []
+        seen: set[str] = set()
+        for info in self.list():
+            if info.name in seen:
+                duplicates.append(info.name)
+            seen.add(info.name)
+            if not Path(info.path).exists():
+                missing_paths.append(info.name)
+            normalized = normalize_resolution_level(info.resolution_level)
+            if normalized != info.resolution_level:
+                invalid_resolution_levels.append(info.name)
+        if self.malformed_rows:
+            errors.append(f"malformed_rows={len(self.malformed_rows)}")
+        return {
+            "registry_version": REGISTRY_VERSION,
+            "field_count": len(self._fields),
+            "malformed_rows": list(self.malformed_rows),
+            "duplicate_names": duplicates,
+            "missing_paths": missing_paths,
+            "invalid_resolution_levels": invalid_resolution_levels,
+            "errors": errors,
+        }

--- a/virgo2/taxonomy.py
+++ b/virgo2/taxonomy.py
@@ -6,66 +6,51 @@ from .field_types import FieldType
 
 
 @dataclass(frozen=True)
-class TaxonomyDecision:
+class TaxonomyResult:
+    field_name: str
     field_type: str
-    confidence: float
     tags: list[str]
+    confidence: float
+    scores: dict[str, float]
 
 
 class SemanticTaxonomy:
-    PRIORITY = [FieldType.IDENTITY, FieldType.PROJECT, FieldType.PROCEDURAL, FieldType.CONVERSATION]
+    PRIORITY = [FieldType.IDENTITY, FieldType.PROJECT, FieldType.PROCEDURAL, FieldType.TEXT, FieldType.CONVERSATION]
     KEYWORDS: dict[str, dict[str, float]] = {
-        FieldType.IDENTITY: {
-            "my name is": 2.5,
-            "i am": 1.2,
-            "i'm": 1.2,
-            "i like": 1.0,
-            "i prefer": 1.0,
-            "remember that i": 1.4,
-        },
-        FieldType.PROJECT: {
-            "project": 2.0,
-            "virgo": 1.5,
-            "neural field": 1.5,
-            "ddif": 1.4,
-            "repository": 1.1,
-            "architecture": 1.2,
-            "code": 0.8,
-        },
-        FieldType.PROCEDURAL: {
-            "how to": 2.0,
-            "steps": 1.1,
-            "workflow": 1.2,
-            "process": 1.2,
-            "procedure": 1.3,
-        },
+        FieldType.IDENTITY: {"my name is": 3.0, "i am": 1.3, "i'm": 1.3, "i like": 1.2, "i prefer": 1.2},
+        FieldType.PROJECT: {"project": 2.0, "architecture": 1.5, "repository": 1.2, "code": 1.1, "neural field": 1.8, "virgo": 1.8},
+        FieldType.PROCEDURAL: {"how to": 2.6, "steps": 1.4, "workflow": 1.5, "procedure": 1.5},
+        FieldType.TEXT: {" is ": 0.8, " are ": 0.8, " means ": 0.9, "defined": 0.7},
+        FieldType.CONVERSATION: {"hello": 0.8, "thanks": 0.8, "hi": 0.7},
     }
 
     def score_text(self, text: str) -> dict[str, float]:
-        lower = text.lower()
+        lower = f" {text.lower()} "
         scores = {k: 0.0 for k in self.PRIORITY}
-        for tag, weighted_keywords in self.KEYWORDS.items():
-            for phrase, weight in weighted_keywords.items():
+        for field_type in self.PRIORITY:
+            for phrase, weight in self.KEYWORDS[field_type].items():
                 if phrase in lower:
-                    scores[tag] += weight
+                    scores[field_type] += weight
         if max(scores.values()) == 0.0:
             scores[FieldType.CONVERSATION] = 0.1
         return scores
 
-    def classify(self, text: str) -> TaxonomyDecision:
+    def classify(self, text: str) -> TaxonomyResult:
         scores = self.score_text(text)
-        ranked = sorted(self.PRIORITY, key=lambda t: (-scores[t], self.PRIORITY.index(t)))
-        top = ranked[0]
-        total = sum(scores.values()) or 1.0
-        confidence = scores[top] / total
-        tags = [tag for tag in ranked if scores[tag] > 0]
-        return TaxonomyDecision(field_type=top, confidence=confidence, tags=tags)
+        ranked = sorted(self.PRIORITY, key=lambda item: (-scores[item], self.PRIORITY.index(item)))
+        selected = ranked[0]
+        total = sum(scores.values())
+        confidence = scores[selected] / total if total > 0 else 0.0
+        confidence = min(1.0, max(0.0, confidence))
+        tags = [item for item in ranked if scores[item] > 0]
+        field_name = f"{selected}_core"
+        return TaxonomyResult(field_name=field_name, field_type=selected, tags=tags, confidence=confidence, scores=scores)
 
     def tags_for(self, text: str) -> list[str]:
-        return self.classify(text).tags or [FieldType.CONVERSATION]
+        return self.classify(text).tags
+
+    def field_for(self, text: str) -> str:
+        return self.classify(text).field_name
 
     def kind_for(self, text: str) -> str:
         return self.classify(text).field_type
-
-    def field_for(self, text: str) -> str:
-        return f"{self.kind_for(text)}_core"


### PR DESCRIPTION
### Motivation
- Prepare Virgo-2 for a stable pre-1.0 milestone by hardening deterministic behaviors, observability, and release validation surfaces without changing architecture. 
- Reduce brittle heuristics (taxonomy, reflection, registry parsing) and provide explicit, testable release readiness signals for lifecycle and ForgeLite. 
- Expose small, safe CLI operations for release validation and registry inspection to enable reproducible smoke tests. 
- Document release state, public API, and remaining limitations to support a conservative `0.9.0` release decision.

### Description
- Implemented a structured, weighted taxonomy with `TaxonomyResult` including `field_name`, `field_type`, `tags`, `confidence`, and `scores`, while preserving `tags_for`, `field_for`, and `kind_for` compatibility and deterministic ordering (`virgo2/taxonomy.py`).
- Hardened reflection by expanding `ReflectionReport`, adding `to_dict()`, deterministic repeated-theme extraction, deduplicated stable-fact extraction/promotion, and promotion-loop prevention (checks destination before ingest) (`virgo2/reflection.py`).
- Improved lifecycle observability by adding `status()` fields (`registry_path`, `field_count`) and a `release_check()` summarizing registry load, dirty/fit/maintenance signals, oversized fields, lineage issues, and a `ready` boolean (`virgo2/lifecycle.py`).
- Strengthened registry robustness with malformed-row tracking during `load()` and a new `validate()` method that reports `malformed_rows`, `duplicate_names`, `missing_paths`, `invalid_resolution_levels`, and aggregate `errors` (`virgo2/registry.py`).
- Upgraded `ForgeLite` with `release_check()` that classifies blocking issues and warnings and returns `{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a102b723fc48322b52e08420ad242cf)