### PR TITLE
Add reality-phase completion report and harden chat CLI contract

### DIFF
--- a/docs/REALITY_PHASE_COMPLETION_REPORT.md
+++ b/docs/REALITY_PHASE_COMPLETION_REPORT.md
@@ -1,0 +1,83 @@
+# Virgo-2 Reality Phase Completion Report
+
+## Date
+2026-05-22
+
+## Executive Summary
+READY FOR 1.0 MEMORY SUBSTRATE + BETA LM
+
+## Version Recommendation
+tag 1.0.0 memory substrate + beta LM
+
+## Commands Run
+- `python -m pip install -e ".[dev]"`
+- `ruff check .`
+- `python -m pytest`
+- `virgo2 --help`
+- `virgo2 lm-train <tmp>/corpus.txt <tmp>/model --epochs 5`
+- `virgo2 lm-generate <tmp>/model "hello" --max-chars 40`
+- `virgo2 lm-evaluate <tmp>/model <tmp>/corpus.txt --report <tmp>/lm_eval.md`
+- `virgo2 ddif-reconstruct <tmp>/corpus.txt <tmp>/ddif_model`
+- `virgo2 ddif-sample <tmp>/ddif_model --prompt "hello"`
+- `virgo2 vault-init <tmp>/vault`
+- `virgo2 remember <tmp>/vault "Virgo stores memory"`
+- `virgo2 recall <tmp>/vault "Virgo"`
+- `virgo2 chat <tmp>/vault <tmp>/model "hello memory" --session-id s1 --max-chars 40 --seed 1`
+- `virgo2 session-start <tmp>/vault --session-id s2`
+- `virgo2 session-add <tmp>/vault s2 user "hi"`
+- `virgo2 session-context <tmp>/vault s2 "hi"`
+- `virgo2 maintenance-cycle <tmp>/vault`
+- `virgo2 forge-check <tmp>/vault`
+- `virgo2 release-check <tmp>/vault`
+- `virgo2 registry-validate <tmp>/vault`
+- `virgo2 taxonomy-classify "Need to plan my tasks"`
+
+## Test Results
+- `ruff check .` -> All checks passed.
+- `python -m pytest` -> 36 passed.
+
+## Full Module Audit
+All `virgo2/` modules were reviewed against the current tests and CLI coverage baseline. Memory substrate and lifecycle modules are stable or complete with limitations. DDiF and LM modules are wired and operational as required beta-core components.
+
+## Full CLI Audit
+All listed commands appear in `virgo2 --help`. Required smoke invocations succeeded for LM, DDiF, vault/memory, lifecycle, registry, and taxonomy commands.
+
+## DDiF Status
+- Contract exists via `ddif-reconstruct` and `ddif-sample` path.
+- Tiny-corpus distillation and sampling succeeded.
+- Limitations: compact implementation and minimal metrics compared with large-scale DDiF systems.
+
+## LM Status
+- Contract exists via train/generate/evaluate and checkpoint loading.
+- Deterministic and seeded behavior covered in tests.
+- Limitations: small char-level neural-field model; no GPT/LLaMA parity claims.
+
+## LM Evaluation Results
+`virgo2 lm-evaluate` executed successfully on tiny corpus and produced metrics plus markdown report output.
+
+## Chat Path Status
+- `chat` command exists.
+- Retrieval context is included in prompt construction.
+- Generation occurs via local neural-field model.
+- Session writeback stores user and assistant turns.
+- Remaining limitations: response quality depends on tiny model size and training corpus.
+
+## Memory/Lifecycle Status
+Retrieve -> generate -> writeback is represented in `chat` command flow. Salience/fit lifecycle remains deferred through maintenance commands rather than forced heavy retraining during chat.
+
+## Documentation Audit
+Docs were checked for consistency with neural-field LM direction and beta-core DDiF/LM maturity framing.
+
+## Blockers Found
+No blocking issues found for the recommended release tier.
+
+## Fixes Applied
+- Added `--max-chars` and `--seed` options to `virgo2 chat`.
+- Added explicit `storage_result` in chat output payload.
+
+## Remaining Limitations
+- Current LM/DDiF stack is beta-core and small-scale.
+- Evaluation remains compact and should be expanded for broader benchmarks.
+
+## Final Recommendation
+Proceed with memory-substrate stable release framing and beta-core LM/DDiF framing, with continued iterative hardening and expanded benchmarks.

--- a/virgo2/cli.py
+++ b/virgo2/cli.py
@@ -130,6 +130,8 @@ def main() -> None:
     chat.add_argument("model_dir")
     chat.add_argument("message")
     chat.add_argument("--session-id", default=None)
+    chat.add_argument("--max-chars", type=int, default=180)
+    chat.add_argument("--seed", type=int, default=0)
 
     # New automation commands
     create_field = sub.add_parser("create-field")
@@ -306,14 +308,22 @@ def main() -> None:
         manager = _manager(args.vault_dir)
         model = NeuralFieldLanguageModel.load(args.model_dir)
         session = SessionOverlay(manager, session_id=args.session_id)
-        session.add_turn("user", args.message)
+        user_storage = session.add_turn("user", args.message)
         retrieved = manager.retrieve(args.message, k=6)
         context_summary = "\n".join(item.record.text for item in retrieved)
         prompt = args.message if not context_summary else f"{context_summary}\nUser: {args.message}\nAssistant:"
-        response = model.generate(prompt, max_chars=180, deterministic=True)
+        response = model.generate(prompt, max_chars=args.max_chars, seed=args.seed, deterministic=False)
         response_text = response[len(prompt):].strip() or response.strip()
-        session.add_turn("assistant", response_text)
-        print({"response": response_text, "retrieved_context_summary": context_summary, "session_field": session.info.field_name, "generation_metrics": {"deterministic": True, "max_chars": 180}})
+        assistant_storage = session.add_turn("assistant", response_text)
+        print(
+            {
+                "response": response_text,
+                "retrieved_context_summary": context_summary,
+                "session_field": session.info.field_name,
+                "generation_metrics": {"deterministic": False, "max_chars": args.max_chars, "seed": args.seed},
+                "storage_result": {"user": str(user_storage), "assistant": str(assistant_storage)},
+            }
+        )
     elif args.cmd == "create-field":
         manager = _manager(args.vault_dir)
         lines = [line for line in Path(args.input_txt).read_text(encoding="utf-8").splitlines() if line.strip()]


### PR DESCRIPTION
### Motivation
- Provide a documented reality-phase completion report that records commands run, test results, and an evidence-backed readiness recommendation for the neural-field LM and DDiF stack.  
- Harden the memory-aware `chat` CLI to match required contract elements (seeded/deterministic generation, max length, retrieval → generate → writeback loop, and explicit storage evidence).  
- Make minimal, targeted changes that preserve engineering discipline and avoid external dependencies or hidden behavior.

### Description
- Added `docs/REALITY_PHASE_COMPLETION_REPORT.md` containing the release-readiness structure, commands run, test results, module/CLI audit summaries, DDiF/LM status, chat-path status, limitations, and a clear recommendation.  
- Extended `virgo2 chat` CLI in `virgo2/cli.py` with `--max-chars` and `--seed` options and wired those into the model generation call to support seeded and max-length generation.  
- Updated chat flow to persist the user turn and assistant turn and return explicit `storage_result` metadata and generation metadata (`seed`, `max_chars`, deterministic flag) in the printed response payload while preserving retrieval context inclusion.  
- Kept all changes local and deterministic where possible and avoided adding new dependencies or external LLM calls.

### Testing
- Performed install and lint: `python -m pip install -e ".[dev]"` and `ruff check .` and observed no issues.  
- Ran unit tests: `python -m pytest` with results `36 passed`.  
- Executed CLI smoke flows in a temporary directory including `virgo2 lm-train`, `virgo2 lm-generate`, `virgo2 lm-evaluate` (with `--report`), `virgo2 ddif-reconstruct`, `virgo2 ddif-sample`, `virgo2 vault-init`, `virgo2 remember`, `virgo2 recall`, and `virgo2 chat --session-id <id> --max-chars <n> --seed <s>`; all smoke invocations succeeded.  
- Confirmed `virgo2 --help` includes the updated `chat` command and options and that the chat output contains retrieval summary, response text, generation metrics, and `storage_result` evidence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a103bf3a3708322ba5332adbcf0feb9)